### PR TITLE
feat: Get connected world by wallet

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -42,8 +42,8 @@ COMMS_FIXED_ADAPTER=ws-room:ws-room-service.decentraland.org/rooms/test-scene
 
 #COMMS_ADAPTER=livekit
 #LIVEKIT_HOST=
-#LIVEKIT_API_KEY=
-#LIVEKIT_API_SECRET=
+LIVEKIT_API_KEY=livekit_api_key
+LIVEKIT_API_SECRET=livekit_api_secret
 
 # number of ms that the deployment has to be newer than
 DEPLOYMENT_TTL=300000

--- a/src/adapters/livekit-client.ts
+++ b/src/adapters/livekit-client.ts
@@ -1,0 +1,22 @@
+import { WebhookReceiver } from 'livekit-server-sdk'
+import { AppComponents, LivekitClient } from '../types'
+
+export enum WebhookEventName {
+  ParticipantJoined = 'participant_joined',
+  ParticipantLeft = 'participant_left'
+}
+
+export type ParticipantEvent = WebhookEventName.ParticipantJoined | WebhookEventName.ParticipantLeft
+
+export async function createLivekitClient({ config }: Pick<AppComponents, 'config'>): Promise<LivekitClient> {
+  const apiKey = await config.requireString('LIVEKIT_API_KEY')
+  const apiSecret = await config.requireString('LIVEKIT_API_SECRET')
+
+  const receiver = new WebhookReceiver(apiKey, apiSecret)
+
+  return {
+    receiveWebhookEvent: async (body: string, authorization: string) => {
+      return receiver.receive(body, authorization)
+    }
+  }
+}

--- a/src/adapters/peers-registry.ts
+++ b/src/adapters/peers-registry.ts
@@ -1,0 +1,23 @@
+import { IPeersRegistry } from '../types'
+
+export async function createPeersRegistry(): Promise<IPeersRegistry> {
+  const connectedPeers = new Map<string, string>()
+
+  function onPeerConnected(id: string, world: string): void {
+    connectedPeers.set(id, world)
+  }
+
+  function onPeerDisconnected(id: string): void {
+    connectedPeers.delete(id)
+  }
+
+  function getPeerWorld(id: string): string | undefined {
+    return connectedPeers.get(id)
+  }
+
+  return {
+    onPeerConnected,
+    onPeerDisconnected,
+    getPeerWorld
+  }
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -37,6 +37,8 @@ import { createAwsConfig } from './adapters/aws-config'
 import { S3 } from 'aws-sdk'
 import { createNotificationsClientComponent } from './adapters/notifications-service'
 import { createNatsComponent } from '@well-known-components/nats-component'
+import { createLivekitClient } from './adapters/livekit-client'
+import { createPeersRegistry } from './adapters/peers-registry'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -151,6 +153,9 @@ export async function initComponents(): Promise<AppComponents> {
     walletStats
   })
 
+  const peersRegistry = await createPeersRegistry()
+  const livekitClient = await createLivekitClient({ config })
+
   return {
     awsConfig,
     commsAdapter,
@@ -160,6 +165,7 @@ export async function initComponents(): Promise<AppComponents> {
     ethereumProvider,
     fetch,
     limitsManager,
+    livekitClient,
     logs,
     marketplaceSubGraph,
     metrics,
@@ -170,6 +176,7 @@ export async function initComponents(): Promise<AppComponents> {
     namePermissionChecker,
     notificationService,
     permissionsManager,
+    peersRegistry,
     server,
     snsClient,
     status,

--- a/src/controllers/handlers/livekit-webhook-handler.ts
+++ b/src/controllers/handlers/livekit-webhook-handler.ts
@@ -1,87 +1,73 @@
 import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
-import { HandlerContextWithPath } from '../../types'
-import { WebhookReceiver } from 'livekit-server-sdk'
+import { HandlerContextWithPath, IPeersRegistry } from '../../types'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
-
-enum WebhookEvent {
-  ParticipantJoined = 'participant_joined',
-  ParticipantLeft = 'participant_left'
-}
+import { InvalidRequestError } from '@dcl/platform-server-commons'
+import { ParticipantEvent, WebhookEventName } from '../../adapters/livekit-client'
 
 const TOPIC_SUFFIX_BY_EVENT = {
-  [WebhookEvent.ParticipantJoined]: 'join',
-  [WebhookEvent.ParticipantLeft]: 'leave'
+  [WebhookEventName.ParticipantJoined]: 'join',
+  [WebhookEventName.ParticipantLeft]: 'leave'
 }
 
-function isValidEvent(event: string): event is keyof typeof WebhookEvent {
-  return Object.values(WebhookEvent).includes(event as WebhookEvent)
+function isValidEvent(event: string): event is ParticipantEvent {
+  return Object.values(WebhookEventName).includes(event as WebhookEventName)
 }
 
 export async function livekitWebhookHandler(
-  ctx: HandlerContextWithPath<'nats' | 'config' | 'logs', '/livekit-webhook'> & DecentralandSignatureContext<any>
+  ctx: HandlerContextWithPath<'nats' | 'logs' | 'livekitClient' | 'peersRegistry', '/livekit-webhook'> &
+    DecentralandSignatureContext<any>
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { nats, config, logs },
+    components: { nats, logs, livekitClient, peersRegistry },
     request
   } = ctx
 
+  const peerRegistryHandlerByEvent: Record<
+    ParticipantEvent,
+    IPeersRegistry[keyof Pick<IPeersRegistry, 'onPeerConnected' | 'onPeerDisconnected'>]
+  > = {
+    [WebhookEventName.ParticipantJoined]: peersRegistry.onPeerConnected,
+    [WebhookEventName.ParticipantLeft]: (identity: string) => peersRegistry.onPeerDisconnected(identity)
+  }
+
   const logger = logs.getLogger('livekit-webhook')
 
-  const apiKey = await config.requireString('LIVEKIT_API_KEY')
-  const apiSecret = await config.requireString('LIVEKIT_API_SECRET')
+  const body = await request.text()
+  const authorization = request.headers.get('Authorization') || ''
 
-  try {
-    const body = await request.text()
-    const authorization = request.headers.get('Authorization') || ''
+  if (!authorization) {
+    throw new InvalidRequestError('Authorization header not found')
+  }
 
-    if (!authorization) {
-      return {
-        status: 400,
-        body: { message: 'Authorization header not found' }
-      }
-    }
+  const { event, participant, room } = await livekitClient.receiveWebhookEvent(body, authorization)
 
-    const receiver = new WebhookReceiver(apiKey, apiSecret)
-    const { event, room, participant } = await receiver.receive(body, authorization)
+  if (!participant?.identity) {
+    throw new InvalidRequestError('Participant identity not found')
+  }
 
-    if (!participant?.identity) {
-      return {
-        status: 400,
-        body: { message: 'Participant identity not found' }
-      }
-    }
+  if (!room?.name) {
+    throw new InvalidRequestError('Room name not found')
+  }
 
-    if (!room?.name) {
-      return {
-        status: 400,
-        body: { message: 'Room name not found' }
-      }
-    }
-
-    if (!isValidEvent(event) || !room.name.endsWith('.dcl.eth')) {
-      logger.info('Skipping event', { event, roomName: room.name })
-      return {
-        status: 200,
-        body: { message: 'Skipping event' }
-      }
-    }
-
-    const { identity } = participant
-
-    logger.debug(`Publishing event ${event} for participant ${identity} in room ${room.name}`)
-    nats.publish(`peer.${identity}.world.${TOPIC_SUFFIX_BY_EVENT[event]}`)
-
+  if (!isValidEvent(event) || !room.name.endsWith('.dcl.eth')) {
+    logger.debug('Skipping event', { event, roomName: room.name })
     return {
       status: 200,
-      body
+      body: { message: 'Skipping event' }
     }
-  } catch (error: any) {
-    return {
-      status: 500,
-      body: {
-        message: 'Error receiving livekit webhook',
-        error: error.message
-      }
-    }
+  }
+
+  const { identity } = participant
+
+  logger.debug(`Publishing event ${event} for participant ${identity} in room ${room.name}`)
+
+  nats.publish(`peer.${identity}.world.${TOPIC_SUFFIX_BY_EVENT[event]}`)
+
+  const peerRegistryHandler = peerRegistryHandlerByEvent[event]
+  peerRegistryHandler(identity, room.name)
+
+  return {
+    status: 200,
+    body
   }
 }

--- a/src/controllers/handlers/wallet-connected-world-handler.ts
+++ b/src/controllers/handlers/wallet-connected-world-handler.ts
@@ -1,0 +1,29 @@
+import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
+import { HandlerContextWithPath } from '../../types'
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { NotFoundError } from '@dcl/platform-server-commons'
+
+export async function walletConnectedWorldHandler(
+  ctx: HandlerContextWithPath<'peersRegistry', '/wallet/:wallet/connected-world'> & DecentralandSignatureContext<any>
+): Promise<IHttpServerComponent.IResponse> {
+  const {
+    components: { peersRegistry },
+    params
+  } = ctx
+
+  const { wallet } = params
+
+  const world = peersRegistry.getPeerWorld(wallet)
+
+  if (!world) {
+    throw new NotFoundError(`Wallet ${wallet} is not connected to any world`)
+  }
+
+  return {
+    status: 200,
+    body: {
+      wallet,
+      world
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -24,6 +24,7 @@ import { reprocessABHandler } from './handlers/reprocess-ab-handler'
 import { garbageCollectionHandler } from './handlers/garbage-collection'
 import { getContributableDomainsHandler } from './handlers/contributor-handler'
 import { livekitWebhookHandler } from './handlers/livekit-webhook-handler'
+import { walletConnectedWorldHandler } from './handlers/wallet-connected-world-handler'
 
 export async function setupRouter(globalContext: GlobalContext): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
@@ -70,6 +71,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   )
 
   router.get('/wallet/:wallet/stats', walletStatsHandler)
+  router.get('/wallet/:wallet/connected-world', walletConnectedWorldHandler)
   router.get('/status', statusHandler)
 
   router.get('/index', getIndexHandler)

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ import {
 } from '@aws-sdk/client-sns'
 import { IFetchComponent } from '@well-known-components/interfaces'
 import { INatsComponent } from '@well-known-components/nats-component/dist/types'
+import { WebhookEvent } from 'livekit-server-sdk'
 
 export type GlobalContext = {
   components: BaseComponents
@@ -260,6 +261,16 @@ export type SnsClient = {
   publishBatch(payload: PublishBatchCommand): Promise<PublishBatchCommandOutput>
 }
 
+export type LivekitClient = {
+  receiveWebhookEvent(body: string, authorization: string): Promise<WebhookEvent>
+}
+
+export type IPeersRegistry = {
+  onPeerConnected(id: string, world: string): void
+  onPeerDisconnected(id: string): void
+  getPeerWorld(id: string): string | undefined
+}
+
 // components used in every environment
 export type BaseComponents = {
   awsConfig: AwsConfig
@@ -270,6 +281,7 @@ export type BaseComponents = {
   ethereumProvider: HTTPProvider
   fetch: IFetchComponent
   limitsManager: ILimitsManager
+  livekitClient: LivekitClient
   logs: ILoggerComponent
   marketplaceSubGraph: ISubgraphComponent
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
@@ -280,6 +292,7 @@ export type BaseComponents = {
   namePermissionChecker: IWorldNamePermissionChecker
   notificationService: INotificationService
   permissionsManager: IPermissionsManager
+  peersRegistry: IPeersRegistry
   server: IHttpServerComponent<GlobalContext>
   snsClient: SnsClient
   status: IStatusComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -28,6 +28,7 @@ import { createMockUpdateOwnerJob } from './mocks/update-owner-job-mock'
 import { createSnsClientMock } from './mocks/sns-client-mock'
 import { createDotEnvConfigComponent } from '@well-known-components/env-config-provider'
 import { createMockNatsComponent } from './mocks/nats-mock'
+import { createMockPeersRegistry } from './mocks/peers-registry-mock'
 
 /**
  * Behaves like Jest "describe" function, used to describe a test for a
@@ -128,6 +129,7 @@ async function initComponents(): Promise<TestComponents> {
     nats: createMockNatsComponent(),
     namePermissionChecker,
     permissionsManager,
+    peersRegistry: createMockPeersRegistry(),
     snsClient,
     status,
     storage,

--- a/test/integration/wallet-connected-world-handler.spec.ts
+++ b/test/integration/wallet-connected-world-handler.spec.ts
@@ -1,0 +1,34 @@
+import { test } from '../components'
+
+test('WalletConnectedWorldHandler', function ({ components, stubComponents }) {
+  async function makeRequest(wallet: string) {
+    const { localFetch } = components
+
+    return localFetch.fetch(`/wallet/${wallet}/connected-world`, {
+      method: 'GET'
+    })
+  }
+
+  it('should return connected world for wallet', async () => {
+    const { peersRegistry } = stubComponents
+    const wallet = '0xtest'
+    const world = 'test-world'
+
+    peersRegistry.getPeerWorld.withArgs(wallet).returns(world)
+
+    const response = await makeRequest(wallet)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      wallet,
+      world
+    })
+  })
+
+  it('should return 404 when wallet is not connected', async () => {
+    const response = await makeRequest('0xnonexistent')
+    expect(response.status).toBe(404)
+    expect(await response.json()).toMatchObject({
+      message: 'Wallet 0xnonexistent is not connected to any world'
+    })
+  })
+})

--- a/test/mocks/peers-registry-mock.ts
+++ b/test/mocks/peers-registry-mock.ts
@@ -1,0 +1,9 @@
+import { IPeersRegistry } from '../../src/types'
+
+export function createMockPeersRegistry(): jest.Mocked<IPeersRegistry> {
+  return {
+    onPeerConnected: jest.fn(),
+    onPeerDisconnected: jest.fn(),
+    getPeerWorld: jest.fn()
+  }
+}

--- a/test/unit/livekit-client.spec.ts
+++ b/test/unit/livekit-client.spec.ts
@@ -1,0 +1,39 @@
+import { WebhookEvent, WebhookReceiver } from 'livekit-server-sdk'
+import { createLivekitClient } from '../../src/adapters/livekit-client'
+import { IConfigComponent } from '@well-known-components/interfaces'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { LivekitClient } from '../../src/types'
+
+jest.mock('livekit-server-sdk')
+
+describe('LivekitClient', () => {
+  let config: IConfigComponent
+  let livekitClient: LivekitClient
+
+  beforeEach(async () => {
+    config = createConfigComponent({
+      LIVEKIT_API_KEY: 'test_api_key',
+      LIVEKIT_API_SECRET: 'test_api_secret'
+    })
+    livekitClient = await createLivekitClient({ config })
+  })
+
+  it('should create a livekit client with correct configuration', async () => {
+    expect(WebhookReceiver).toHaveBeenCalledWith('test_api_key', 'test_api_secret')
+  })
+
+  it('should receive webhook events correctly', async () => {
+    const mockEvent = {
+      event: 'participant_joined',
+      participant: { identity: 'test' },
+      room: { name: 'test' }
+    } as WebhookEvent
+
+    jest.spyOn(WebhookReceiver.prototype, 'receive').mockResolvedValue(mockEvent)
+
+    const result = await livekitClient.receiveWebhookEvent('test-body', 'test-auth')
+
+    expect(result).toEqual(mockEvent)
+    expect(WebhookReceiver.prototype.receive).toHaveBeenCalledWith('test-body', 'test-auth')
+  })
+})

--- a/test/unit/peers-registry.spec.ts
+++ b/test/unit/peers-registry.spec.ts
@@ -1,0 +1,35 @@
+import { createPeersRegistry } from '../../src/adapters/peers-registry'
+import { IPeersRegistry } from '../../src/types'
+
+describe('PeersRegistry', () => {
+  let peersRegistry: IPeersRegistry
+
+  beforeEach(async () => {
+    peersRegistry = await createPeersRegistry()
+  })
+
+  it('should track connected peers', async () => {
+    peersRegistry.onPeerConnected('peer1', 'world1')
+    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+  })
+
+  it('should remove disconnected peers', async () => {
+    peersRegistry.onPeerConnected('peer1', 'world1')
+    peersRegistry.onPeerDisconnected('peer1')
+    expect(peersRegistry.getPeerWorld('peer1')).toBeUndefined()
+  })
+
+  it('should update peer world on reconnection', async () => {
+    peersRegistry.onPeerConnected('peer1', 'world1')
+    peersRegistry.onPeerConnected('peer1', 'world2')
+    expect(peersRegistry.getPeerWorld('peer1')).toBe('world2')
+  })
+
+  it('should handle multiple peers', async () => {
+    peersRegistry.onPeerConnected('peer1', 'world1')
+    peersRegistry.onPeerConnected('peer2', 'world2')
+
+    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+    expect(peersRegistry.getPeerWorld('peer2')).toBe('world2')
+  })
+})


### PR DESCRIPTION
- Added new blocks table with blocker/blocked addresses and timestamps
- Implemented block user RPC endpoints (blockUser, unblockUser, getBlockedUsers)
- Added real-time block status subscriptions via subscribeToBlockUpdates
- Integrated blocking with existing friendship system (migrating common queries to new file: `queries.ts`)