### PR TITLE
feat: report isMultiplayer boolean in SNS message attributes

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -11,7 +11,7 @@ HTTP_SERVER_PORT=3000
 HTTP_SERVER_HOST=0.0.0.0
 #HTTP_BASE_URL=https://worlds-content-server.decentraland.org
 
-#PG_COMPONENT_PSQL_CONNECTION_STRING=postgres://{user}:{pass}@{hostname}:{port}/{database}
+PG_COMPONENT_PSQL_CONNECTION_STRING=postgres://postgres:pass1234@localhost:5450/world_content_server
 
 AWS_REGION=us-east-1
 
@@ -20,7 +20,7 @@ MARKETPLACE_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/decentraland/ma
 BUILDER_URL=https://decentraland.org/builder
 ALLOW_ENS_DOMAINS=false
 
-SNS_ARN=
+SNS_ARN=<PLACEHOLDER>
 AUTH_SECRET="setup_some_secret_here"
 
 LAMBDAS_URL=https://peer.decentraland.org/lambdas

--- a/src/adapters/entity-deployer.ts
+++ b/src/adapters/entity-deployer.ts
@@ -82,10 +82,12 @@ export function createEntityDeployer(
         },
         contentServerUrls: [baseUrl]
       }
-      const receipt = await snsPublish(snsClient, snsArn, deploymentToSqs)
+      const isMultiplayer = !!entity.metadata?.multiplayerId
+      const receipt = await snsPublish(snsClient, snsArn, deploymentToSqs, { isMultiplayer })
       logger.info('notification sent', {
         MessageId: `${receipt.MessageId}`,
-        SequenceNumber: `${receipt.SequenceNumber}`
+        SequenceNumber: `${receipt.SequenceNumber}`,
+        isMultiplayer: isMultiplayer ? 'true' : 'false'
       })
     }
 

--- a/src/logic/sns.ts
+++ b/src/logic/sns.ts
@@ -8,7 +8,8 @@ import { Events } from '@dcl/schemas'
 export async function snsPublish(
   client: SnsClient,
   snsArn: string,
-  deploymentToSqs: DeploymentToSqs
+  deploymentToSqs: DeploymentToSqs,
+  opts?: { isMultiplayer?: boolean }
 ): Promise<PublishCommandOutput> {
   const sendCommand = new PublishCommand({
     TopicArn: snsArn,
@@ -25,6 +26,10 @@ export async function snsPublish(
       priority: {
         DataType: 'String',
         StringValue: '1'
+      },
+      isMultiplayer: {
+        DataType: 'String',
+        StringValue: opts?.isMultiplayer ? 'true' : 'false'
       }
     }
   })

--- a/test/components.ts
+++ b/test/components.ts
@@ -119,6 +119,7 @@ async function initComponents(): Promise<TestComponents> {
 
   return {
     ...components,
+    config,
     commsAdapter,
     entityDeployer,
     fetch,

--- a/test/integration/deploy.spec.ts
+++ b/test/integration/deploy.spec.ts
@@ -48,7 +48,7 @@ test('deployment works', function ({ components, stubComponents }) {
     const { storage, worldsManager } = components
     const { snsClient } = stubComponents
 
-    ;(snsClient.publish as any).mockClear()
+    snsClient.publish.resetHistory()
 
     entityFiles.set('abc.txt', stringToUtf8Bytes(makeid(100)))
     const fileHash = await hashV1(entityFiles.get('abc.txt')!)
@@ -80,10 +80,14 @@ test('deployment works', function ({ components, stubComponents }) {
 
     const authChain = Authenticator.signPayload(identity.authChain, entityId)
 
-    snsClient.publish.resolves({
-      MessageId: 'mocked-message-id',
-      SequenceNumber: 'mocked-sequence-number',
-      $metadata: {}
+    let lastCmd: any
+    snsClient.publish.callsFake((cmd: any) => {
+      lastCmd = cmd
+      return Promise.resolve({
+        MessageId: 'mocked-message-id',
+        SequenceNumber: 'mocked-sequence-number',
+        $metadata: {}
+      })
     })
 
     const response = (await contentClient.deploy({ files, entityId, authChain })) as Response
@@ -115,16 +119,16 @@ test('deployment works', function ({ components, stubComponents }) {
 
     Sinon.assert.calledWithMatch(stubComponents.metrics.increment, 'world_deployments_counter', { kind: 'dcl-name' })
 
-    // Assert SNS attribute isMultiplayer = false when no multiplayerId
-    const publishArg = (snsClient.publish as any).mock.calls[0][0]
-    expect(publishArg.input.MessageAttributes.isMultiplayer.StringValue).toBe('false')
+    // Explicit post-call assertion
+    Sinon.assert.calledOnce(snsClient.publish as any)
+    expect(lastCmd?.input?.MessageAttributes?.isMultiplayer?.StringValue).toBe('false')
   })
 
   it('creates an entity and deploys it (authorized wallet)', async () => {
     const { storage, worldsManager } = components
     const { snsClient } = stubComponents
 
-    ;(snsClient.publish as any).mockClear()
+    snsClient.publish.resetHistory()
 
     const delegatedIdentity = await getIdentity()
 
@@ -193,14 +197,20 @@ test('deployment works', function ({ components, stubComponents }) {
   it('sets isMultiplayer attribute to true when multiplayerId is present', async () => {
     const { snsClient } = stubComponents
 
-    ;(snsClient.publish as any).mockClear()
+    snsClient.publish.resetHistory()
 
     // Build the entity with multiplayerId
+    entityFiles.set('abc.txt', stringToUtf8Bytes(makeid(100)))
     const { files, entityId } = await DeploymentBuilder.buildEntity({
       type: EntityType.SCENE as any,
       pointers: ['0,0'],
       files: entityFiles,
       metadata: {
+        main: 'abc.txt',
+        scene: {
+          base: '0,0',
+          parcels: ['0,0']
+        },
         multiplayerId: 'room-123',
         worldConfiguration: {
           name: worldName
@@ -210,17 +220,21 @@ test('deployment works', function ({ components, stubComponents }) {
 
     const authChain = Authenticator.signPayload(identity.authChain, entityId)
 
-    snsClient.publish.resolves({
-      MessageId: 'mocked-message-id',
-      SequenceNumber: 'mocked-sequence-number',
-      $metadata: {}
+    let lastCmdTrue: any
+    snsClient.publish.callsFake((cmd: any) => {
+      lastCmdTrue = cmd
+      return Promise.resolve({
+        MessageId: 'mocked-message-id',
+        SequenceNumber: 'mocked-sequence-number',
+        $metadata: {}
+      })
     })
 
     await contentClient.deploy({ files, entityId, authChain })
 
-    // Assert SNS attribute isMultiplayer = true when multiplayerId is present
-    const publishArg = (snsClient.publish as any).mock.calls[0][0]
-    expect(publishArg.input.MessageAttributes.isMultiplayer.StringValue).toBe('true')
+    // Explicit post-call assertion
+    Sinon.assert.calledOnce(snsClient.publish as any)
+    expect(lastCmdTrue?.input?.MessageAttributes?.isMultiplayer?.StringValue).toBe('true')
   })
 
   it('creates an entity and deploys it using uppercase letters in the name', async () => {

--- a/test/unit/sns.spec.ts
+++ b/test/unit/sns.spec.ts
@@ -1,0 +1,98 @@
+import { snsPublish, snsPublishBatch } from '../../src/logic/sns'
+import { SnsClient } from '../../src/types'
+
+describe('when publishing deployments to SNS', () => {
+  let arn: string
+  let deployment: any
+  let client: SnsClient
+  let publish: jest.Mock
+  let publishBatch: jest.Mock
+
+  beforeEach(() => {
+    arn = 'arn:aws:sns:region:account:topic'
+    deployment = {
+      entity: { entityId: 'eid', authChain: [] },
+      contentServerUrls: ['http://base']
+    }
+
+    publish = jest.fn()
+    publishBatch = jest.fn()
+    client = {} as unknown as SnsClient
+    ;(client as any).publish = publish
+    ;(client as any).publishBatch = publishBatch
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when calling snsPublish', () => {
+    describe('and isMultiplayer option is true', () => {
+      let sentCommand: any
+
+      beforeEach(async () => {
+        publish.mockResolvedValue({ MessageId: 'm', SequenceNumber: '1', $metadata: {} })
+        await snsPublish(client, arn, deployment, { isMultiplayer: true })
+        sentCommand = publish.mock.calls[0][0]
+      })
+
+      it('should include isMultiplayer=true in the message attributes', () => {
+        expect(sentCommand.input.MessageAttributes.isMultiplayer.StringValue).toBe('true')
+      })
+    })
+
+    describe('and isMultiplayer option is omitted', () => {
+      let sentCommand: any
+
+      beforeEach(async () => {
+        publish.mockResolvedValue({ MessageId: 'm', SequenceNumber: '1', $metadata: {} })
+        await snsPublish(client, arn, deployment)
+        sentCommand = publish.mock.calls[0][0]
+      })
+
+      it('should include isMultiplayer=false in the message attributes', () => {
+        expect(sentCommand.input.MessageAttributes.isMultiplayer.StringValue).toBe('false')
+      })
+    })
+  })
+
+  describe('when calling snsPublishBatch', () => {
+    let sentBatchCommand: any
+    let result: any
+
+    beforeEach(async () => {
+      publishBatch.mockImplementation((cmd: any) => {
+        const entries = cmd.input.PublishBatchRequestEntries
+        return Promise.resolve({
+          Successful: entries.map((e: any) => ({ Id: e.Id, MessageId: 'm', SequenceNumber: '1' })),
+          Failed: [],
+          $metadata: {}
+        })
+      })
+
+      result = await snsPublishBatch(client, arn, [
+        deployment,
+        { ...deployment, entity: { entityId: 'eid2', authChain: [] } }
+      ])
+      sentBatchCommand = publishBatch.mock.calls[0][0]
+    })
+
+    it('should include exactly two entries', () => {
+      expect(sentBatchCommand.input.PublishBatchRequestEntries).toHaveLength(2)
+    })
+
+    it('should include type attribute set to world for all entries', () => {
+      const entries: any[] = sentBatchCommand.input.PublishBatchRequestEntries
+      expect(entries.every((e) => e.MessageAttributes.type.StringValue === 'world')).toBe(true)
+    })
+
+    it('should include subType attribute set to deployment for all entries', () => {
+      const entries: any[] = sentBatchCommand.input.PublishBatchRequestEntries
+      expect(entries.every((e) => e.MessageAttributes.subType.StringValue === 'deployment')).toBe(true)
+    })
+
+    it('should aggregate all entries as Successful with no failures', () => {
+      expect(result.Successful?.length).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
This PR proposes to identify multiplayer worlds by SNS message attributes so they can be routed to specific multiplayer server listeners.