### PR TITLE
fix: Remove comms prefix from world name in Wallet Connected World response

### DIFF
--- a/src/adapters/peers-registry.ts
+++ b/src/adapters/peers-registry.ts
@@ -1,9 +1,11 @@
-import { IPeersRegistry } from '../types'
+import { AppComponents, IPeersRegistry } from '../types'
 
-export async function createPeersRegistry(): Promise<IPeersRegistry> {
+export async function createPeersRegistry({ config }: Pick<AppComponents, 'config'>): Promise<IPeersRegistry> {
+  const roomPrefix = await config.requireString('COMMS_ROOM_PREFIX')
   const connectedPeers = new Map<string, string>()
 
-  function onPeerConnected(id: string, world: string): void {
+  function onPeerConnected(id: string, roomName: string): void {
+    const world = roomName.startsWith(roomPrefix) ? roomName.substring(roomPrefix.length) : roomName
     connectedPeers.set(id.toLowerCase(), world)
   }
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -153,7 +153,7 @@ export async function initComponents(): Promise<AppComponents> {
     walletStats
   })
 
-  const peersRegistry = await createPeersRegistry()
+  const peersRegistry = await createPeersRegistry({ config })
   const livekitClient = await createLivekitClient({ config })
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,7 +258,7 @@ export type LivekitClient = {
 }
 
 export type IPeersRegistry = {
-  onPeerConnected(id: string, world: string): void
+  onPeerConnected(id: string, roomName: string): void
   onPeerDisconnected(id: string): void
   getPeerWorld(id: string): string | undefined
 }

--- a/test/integration/wallet-connected-world-handler.spec.ts
+++ b/test/integration/wallet-connected-world-handler.spec.ts
@@ -9,26 +9,85 @@ test('WalletConnectedWorldHandler', function ({ components, stubComponents }) {
     })
   }
 
-  it('should return connected world for wallet', async () => {
-    const { peersRegistry } = stubComponents
-    const wallet = '0xtest'
-    const world = 'test-world'
+  beforeEach(async () => {
+    const { config } = stubComponents
+    config.requireString.withArgs('COMMS_ROOM_PREFIX').resolves('world-test-')
+  })
 
-    peersRegistry.getPeerWorld.withArgs(wallet).returns(world)
+  describe('when requesting connected world for a wallet', () => {
+    it('should return connected world for wallet', async () => {
+      const { peersRegistry } = stubComponents
+      const wallet = '0xtest'
+      const world = 'test-world'
 
-    const response = await makeRequest(wallet)
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({
-      wallet,
-      world
+      peersRegistry.getPeerWorld.withArgs(wallet).returns(world)
+
+      const response = await makeRequest(wallet)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        wallet,
+        world
+      })
+    })
+
+    it('should return connected world with stripped prefix', async () => {
+      const { peersRegistry } = stubComponents
+      const wallet = '0xtest'
+      const world = 'my-world' // This would be the result after prefix stripping
+
+      peersRegistry.getPeerWorld.withArgs(wallet).returns(world)
+
+      const response = await makeRequest(wallet)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        wallet,
+        world
+      })
+    })
+
+    it('should handle wallet with different case', async () => {
+      const { peersRegistry } = stubComponents
+      const wallet = '0xTEST'
+      const world = 'test-world'
+
+      peersRegistry.getPeerWorld.withArgs(wallet).returns(world)
+
+      const response = await makeRequest(wallet)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        wallet,
+        world
+      })
     })
   })
 
-  it('should return 404 when wallet is not connected', async () => {
-    const response = await makeRequest('0xnonexistent')
-    expect(response.status).toBe(404)
-    expect(await response.json()).toMatchObject({
-      message: 'Wallet 0xnonexistent is not connected to any world'
+  describe('when wallet is not connected', () => {
+    it('should return 404 when wallet is not connected', async () => {
+      const response = await makeRequest('0xnonexistent')
+      expect(response.status).toBe(404)
+      expect(await response.json()).toMatchObject({
+        message: 'Wallet 0xnonexistent is not connected to any world'
+      })
+    })
+
+    it('should return 404 for empty wallet address', async () => {
+      const response = await makeRequest('')
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('when peers registry returns undefined', () => {
+    it('should return 404 when peers registry returns undefined', async () => {
+      const { peersRegistry } = stubComponents
+      const wallet = '0xtest'
+
+      peersRegistry.getPeerWorld.withArgs(wallet).returns(undefined)
+
+      const response = await makeRequest(wallet)
+      expect(response.status).toBe(404)
+      expect(await response.json()).toMatchObject({
+        message: `Wallet ${wallet} is not connected to any world`
+      })
     })
   })
 })

--- a/test/unit/peers-registry.spec.ts
+++ b/test/unit/peers-registry.spec.ts
@@ -1,45 +1,91 @@
 import { createPeersRegistry } from '../../src/adapters/peers-registry'
 import { IPeersRegistry } from '../../src/types'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { IConfigComponent } from '@well-known-components/interfaces'
 
 describe('PeersRegistry', () => {
   let peersRegistry: IPeersRegistry
+  let config: IConfigComponent
 
   beforeEach(async () => {
-    peersRegistry = await createPeersRegistry()
+    config = createConfigComponent({ COMMS_ROOM_PREFIX: 'world-test-' })
+    peersRegistry = await createPeersRegistry({ config })
   })
 
-  it('should track connected peers', async () => {
-    peersRegistry.onPeerConnected('peer1', 'world1')
-    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+  describe('when a peer connects', () => {
+    it('should track connected peers with room name as world', () => {
+      peersRegistry.onPeerConnected('peer1', 'world1')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+    })
+
+    it('should track connected peers with lowercase ids', () => {
+      peersRegistry.onPeerConnected('PEER1', 'world1')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+    })
+
+    it('should strip room prefix from room name when present', () => {
+      peersRegistry.onPeerConnected('peer1', 'world-test-myworld')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('myworld')
+    })
+
+    it('should keep full room name when prefix is not present', () => {
+      peersRegistry.onPeerConnected('peer1', 'myworld')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('myworld')
+    })
+
+    it('should handle room names that start with prefix but have additional content', () => {
+      peersRegistry.onPeerConnected('peer1', 'world-test-complex-world-name')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('complex-world-name')
+    })
+
+    it('should handle multiple peers with different room formats', () => {
+      peersRegistry.onPeerConnected('peer1', 'world-test-world1')
+      peersRegistry.onPeerConnected('peer2', 'world2')
+      peersRegistry.onPeerConnected('peer3', 'world-test-complex-name')
+
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+      expect(peersRegistry.getPeerWorld('peer2')).toBe('world2')
+      expect(peersRegistry.getPeerWorld('peer3')).toBe('complex-name')
+    })
   })
 
-  it('should track connected peers with lowercase ids', async () => {
-    peersRegistry.onPeerConnected('PEER1', 'world1')
-    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+  describe('when a peer disconnects', () => {
+    it('should remove disconnected peers', () => {
+      peersRegistry.onPeerConnected('peer1', 'world1')
+      peersRegistry.onPeerDisconnected('peer1')
+      expect(peersRegistry.getPeerWorld('peer1')).toBeUndefined()
+    })
+
+    it('should handle case insensitive peer disconnection', () => {
+      peersRegistry.onPeerConnected('PEER1', 'world1')
+      peersRegistry.onPeerDisconnected('peer1')
+      expect(peersRegistry.getPeerWorld('peer1')).toBeUndefined()
+    })
   })
 
-  it('should remove disconnected peers', async () => {
-    peersRegistry.onPeerConnected('peer1', 'world1')
-    peersRegistry.onPeerDisconnected('peer1')
-    expect(peersRegistry.getPeerWorld('peer1')).toBeUndefined()
+  describe('when a peer reconnects', () => {
+    it('should update peer world on reconnection', () => {
+      peersRegistry.onPeerConnected('peer1', 'world1')
+      peersRegistry.onPeerConnected('peer1', 'world2')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('world2')
+    })
+
+    it('should update peer world with prefix stripping on reconnection', () => {
+      peersRegistry.onPeerConnected('peer1', 'world1')
+      peersRegistry.onPeerConnected('peer1', 'world-test-new-world')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('new-world')
+    })
   })
 
-  it('should track connected peers with lowercase ids', async () => {
-    peersRegistry.onPeerConnected('PEER1', 'world1')
-    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
-  })
+  describe('when querying peer world', () => {
+    it('should return undefined for unknown peer', () => {
+      expect(peersRegistry.getPeerWorld('unknown')).toBeUndefined()
+    })
 
-  it('should update peer world on reconnection', async () => {
-    peersRegistry.onPeerConnected('peer1', 'world1')
-    peersRegistry.onPeerConnected('peer1', 'world2')
-    expect(peersRegistry.getPeerWorld('peer1')).toBe('world2')
-  })
-
-  it('should handle multiple peers', async () => {
-    peersRegistry.onPeerConnected('peer1', 'world1')
-    peersRegistry.onPeerConnected('peer2', 'world2')
-
-    expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
-    expect(peersRegistry.getPeerWorld('peer2')).toBe('world2')
+    it('should handle case insensitive queries', () => {
+      peersRegistry.onPeerConnected('PEER1', 'world1')
+      expect(peersRegistry.getPeerWorld('peer1')).toBe('world1')
+      expect(peersRegistry.getPeerWorld('PEER1')).toBe('world1')
+    })
   })
 })


### PR DESCRIPTION
Closes #397 