### PR TITLE
feat: publish deployments as priority

### DIFF
--- a/src/adapters/entity-deployer.ts
+++ b/src/adapters/entity-deployer.ts
@@ -86,7 +86,8 @@ export function createEntityDeployer(
       }
       const isMultiplayer = !!entity.metadata?.multiplayerId
       const receipt = await snsClient.publishMessage(deploymentToSqs, {
-        isMultiplayer: { DataType: 'String', StringValue: isMultiplayer ? 'true' : 'false' }
+        isMultiplayer: { DataType: 'String', StringValue: isMultiplayer ? 'true' : 'false' },
+        priority: { DataType: 'String', StringValue: '1' }
       })
       logger.info('notification sent', {
         MessageId: `${receipt.MessageId}`,


### PR DESCRIPTION
Deployments need to be marked as a priority so AB Converter servers can retrieve them more quickly and prioritize them over re-deployments.