### PR TITLE
feat: Add deployer filter to world and scene endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -129,7 +129,7 @@ paths:
           required: false
           schema: { type: integer, minimum: 0 }
           description: 'Number of scenes to skip (default 0)'
-        - name: deployer
+        - name: authorized_deployer
           in: query
           required: false
           schema: { type: string }
@@ -215,7 +215,7 @@ paths:
           required: false
           schema: { type: integer, minimum: 0 }
           description: 'Number of scenes to skip (default 0)'
-        - name: deployer
+        - name: authorized_deployer
           in: query
           required: false
           schema: { type: string }
@@ -775,13 +775,13 @@ paths:
         - Content Server
       summary: GET /worlds
       description: |
-        Retrieve a paginated list of worlds with optional search, sorting, and deployer filtering.
+        Retrieve a paginated list of worlds with optional search, sorting, and authorized deployer filtering.
 
         This endpoint supports:
         - **Pagination**: Use `limit` and `offset` query parameters
         - **Search**: Full-text search across world name, title, and description
         - **Sorting**: Sort by world name or last deployment time
-        - **Deployer filtering**: Filter by worlds where an address can deploy (is owner or has deployment permission)
+        - **Authorized deployer filtering**: Filter by worlds where an address can deploy (is owner or has deployment permission)
       operationId: worldsContentServer_getWorlds
       parameters:
         - name: limit
@@ -824,7 +824,7 @@ paths:
             enum: [asc, desc]
             default: asc
           description: Sort direction (default "asc")
-        - name: deployer
+        - name: authorized_deployer
           in: query
           required: false
           schema:

--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -405,10 +405,10 @@ export async function createWorldsManagerComponent({
       mainQuery.append(bboxCondition)
     }
 
-    // Apply deployer filter: filter by scenes in worlds where deployer is owner or has deployment permission
+    // Apply authorized_deployer filter: filter by scenes in worlds where deployer is owner or has deployment permission
     // Note: owner and address columns are already stored in lowercase
-    if (filters?.deployer) {
-      const normalizedDeployer = filters.deployer.toLowerCase()
+    if (filters?.authorized_deployer) {
+      const normalizedDeployer = filters.authorized_deployer.toLowerCase()
       const deployerCondition = SQL` AND EXISTS (
         SELECT 1 FROM worlds w
         WHERE w.name = world_scenes.world_name
@@ -687,14 +687,14 @@ export async function createWorldsManagerComponent({
   }
 
   /**
-   * Gets a paginated list of worlds with optional search, sorting, and deployer filtering
+   * Gets a paginated list of worlds with optional search, sorting, and authorized_deployer filtering
    *
-   * @param filters - Optional filters for search and deployer address
+   * @param filters - Optional filters for search and authorized_deployer address
    * @param options - Pagination and sorting options
    * @returns Paginated list of worlds with total count
    */
   async function getWorlds(filters: GetWorldsFilters = {}, options: GetWorldsOptions = {}): Promise<GetWorldsResult> {
-    const { search: searchTerm, deployer } = filters
+    const { search: searchTerm, authorized_deployer } = filters
     const { limit = 100, offset = 0, orderBy = WorldsOrderBy.Name, orderDirection = OrderDirection.Asc } = options
 
     // Get banned names to exclude from query
@@ -752,10 +752,10 @@ export async function createWorldsManagerComponent({
       mainQuery.append(bannedFilter)
     }
 
-    // Apply deployer filter: filter by worlds where deployer is owner or has deployment permission
+    // Apply authorized_deployer filter: filter by worlds where deployer is owner or has deployment permission
     // Note: owner and address columns are already stored in lowercase
-    if (deployer) {
-      const normalizedDeployer = deployer.toLowerCase()
+    if (authorized_deployer) {
+      const normalizedDeployer = authorized_deployer.toLowerCase()
       const deployerFilter = SQL` AND (
         w.owner = ${normalizedDeployer}
         OR EXISTS (

--- a/src/controllers/handlers/scenes-handler.ts
+++ b/src/controllers/handlers/scenes-handler.ts
@@ -49,19 +49,19 @@ export async function getScenesHandler(
 
   const { limit, offset } = getPaginationParams(ctx.url.searchParams)
 
-  // Extract deployer filter
-  const deployer = ctx.url.searchParams.get('deployer') ?? undefined
+  // Extract authorized_deployer filter
+  const deployer = ctx.url.searchParams.get('authorized_deployer') ?? undefined
 
-  // Validate deployer is a valid Ethereum address if provided
+  // Validate authorized_deployer is a valid Ethereum address if provided
   if (deployer && !EthAddress.validate(deployer)) {
-    throw new InvalidRequestError(`Invalid deployer address: ${deployer}. Must be a valid Ethereum address.`)
+    throw new InvalidRequestError(`Invalid authorized_deployer address: ${deployer}. Must be a valid Ethereum address.`)
   }
 
   const filters: GetWorldScenesFilters = {
     worldName: world_name,
     ...(coordinates.length > 0 && { coordinates }),
     ...(boundingBox && { boundingBox }),
-    ...(deployer && { deployer })
+    ...(deployer && { authorized_deployer: deployer })
   }
 
   const { scenes, total } = await ctx.components.worldsManager.getWorldScenes(filters, { limit, offset })

--- a/src/controllers/handlers/worlds-handler.ts
+++ b/src/controllers/handlers/worlds-handler.ts
@@ -45,12 +45,12 @@ export async function getWorldsHandler(
   const { limit, offset } = getPaginationParams(ctx.url.searchParams)
 
   // Extract optional query parameters
-  const deployer = ctx.url.searchParams.get('deployer') ?? undefined
+  const deployer = ctx.url.searchParams.get('authorized_deployer') ?? undefined
   const search = ctx.url.searchParams.get('search') ?? undefined
 
-  // Validate deployer is a valid Ethereum address if provided
+  // Validate authorized_deployer is a valid Ethereum address if provided
   if (deployer && !EthAddress.validate(deployer)) {
-    throw new InvalidRequestError(`Invalid deployer address: ${deployer}. Must be a valid Ethereum address.`)
+    throw new InvalidRequestError(`Invalid authorized_deployer address: ${deployer}. Must be a valid Ethereum address.`)
   }
   const sortParam = ctx.url.searchParams.get('sort') ?? WorldsOrderBy.Name
   const orderParam = ctx.url.searchParams.get('order') ?? OrderDirection.Asc
@@ -75,7 +75,7 @@ export async function getWorldsHandler(
   const orderDirection = orderParam as OrderDirection
 
   const { worlds, total } = await ctx.components.worldsManager.getWorlds(
-    { deployer, search },
+    { authorized_deployer: deployer, search },
     { limit, offset, orderBy, orderDirection }
   )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,7 +122,7 @@ export type GetWorldScenesFilters = {
   worldName?: string
   coordinates?: string[]
   boundingBox?: BoundingBox
-  deployer?: string // address to filter scenes by (world owner or has deployment permission)
+  authorized_deployer?: string // address to filter scenes by (world owner or has deployment permission)
 }
 
 export enum SceneOrderBy {
@@ -169,7 +169,7 @@ export type WorldInfo = {
 }
 
 export type GetWorldsFilters = {
-  deployer?: string // address to filter worlds by (owner or has deployment permission)
+  authorized_deployer?: string // address to filter worlds by (owner or has deployment permission)
   search?: string
 }
 

--- a/test/integration/scenes-handler.spec.ts
+++ b/test/integration/scenes-handler.spec.ts
@@ -199,22 +199,24 @@ test('ScenesHandler', function ({ components, stubComponents }) {
         })
       })
 
-      describe('and deployer filter is provided', function () {
-        describe('and the deployer is not a valid Ethereum address', function () {
+      describe('and authorized_deployer filter is provided', function () {
+        describe('and the authorized_deployer is not a valid Ethereum address', function () {
           it('should respond with 400', async () => {
             const { localFetch } = components
 
-            const response = await localFetch.fetch(`/world/${worldName}/scenes?deployer=not-a-valid-address`)
+            const response = await localFetch.fetch(
+              `/world/${worldName}/scenes?authorized_deployer=not-a-valid-address`
+            )
 
             expect(response.status).toBe(400)
             expect(await response.json()).toMatchObject({
               error: 'Bad request',
-              message: expect.stringContaining('Invalid deployer address')
+              message: expect.stringContaining('Invalid authorized_deployer address')
             })
           })
         })
 
-        describe('and the deployer is the owner of the world', function () {
+        describe('and the authorized_deployer is the owner of the world', function () {
           let ownerAddress: string
           let expectedEntityId: string
 
@@ -226,10 +228,10 @@ test('ScenesHandler', function ({ components, stubComponents }) {
             expectedEntityId = metadata!.scenes[0].entityId
           })
 
-          it('should return the scene from the world where the deployer is owner', async () => {
+          it('should return the scene from the world where the authorized_deployer is owner', async () => {
             const { localFetch } = components
 
-            const response = await localFetch.fetch(`/world/${worldName}/scenes?deployer=${ownerAddress}`)
+            const response = await localFetch.fetch(`/world/${worldName}/scenes?authorized_deployer=${ownerAddress}`)
 
             expect(response.status).toBe(200)
             const body = await response.json()
@@ -240,7 +242,7 @@ test('ScenesHandler', function ({ components, stubComponents }) {
           })
         })
 
-        describe('and the deployer has world-wide deployment permission', function () {
+        describe('and the authorized_deployer has world-wide deployment permission', function () {
           let deployerAddress: string
           let expectedEntityId: string
 
@@ -254,10 +256,10 @@ test('ScenesHandler', function ({ components, stubComponents }) {
             expectedEntityId = metadata!.scenes[0].entityId
           })
 
-          it('should return the scene from the world where the deployer has deployment permission', async () => {
+          it('should return the scene from the world where the authorized_deployer has deployment permission', async () => {
             const { localFetch } = components
 
-            const response = await localFetch.fetch(`/world/${worldName}/scenes?deployer=${deployerAddress}`)
+            const response = await localFetch.fetch(`/world/${worldName}/scenes?authorized_deployer=${deployerAddress}`)
 
             expect(response.status).toBe(200)
             const body = await response.json()
@@ -268,7 +270,7 @@ test('ScenesHandler', function ({ components, stubComponents }) {
           })
         })
 
-        describe('and the deployer has parcel-specific deployment permission', function () {
+        describe('and the authorized_deployer has parcel-specific deployment permission', function () {
           let deployerAddress: string
           let expectedEntityId: string
 
@@ -285,10 +287,10 @@ test('ScenesHandler', function ({ components, stubComponents }) {
             await permissions.addParcelsToPermission(worldName, 'deployment', deployerAddress, sceneParcels)
           })
 
-          it('should return the scene from the world where the deployer has parcel permission', async () => {
+          it('should return the scene from the world where the authorized_deployer has parcel permission', async () => {
             const { localFetch } = components
 
-            const response = await localFetch.fetch(`/world/${worldName}/scenes?deployer=${deployerAddress}`)
+            const response = await localFetch.fetch(`/world/${worldName}/scenes?authorized_deployer=${deployerAddress}`)
 
             expect(response.status).toBe(200)
             const body = await response.json()
@@ -299,7 +301,7 @@ test('ScenesHandler', function ({ components, stubComponents }) {
           })
         })
 
-        describe('and the deployer is neither owner nor has permission', function () {
+        describe('and the authorized_deployer is neither owner nor has permission', function () {
           let unknownAddress: string
 
           beforeEach(() => {
@@ -309,7 +311,7 @@ test('ScenesHandler', function ({ components, stubComponents }) {
           it('should return an empty scenes array', async () => {
             const { localFetch } = components
 
-            const response = await localFetch.fetch(`/world/${worldName}/scenes?deployer=${unknownAddress}`)
+            const response = await localFetch.fetch(`/world/${worldName}/scenes?authorized_deployer=${unknownAddress}`)
 
             expect(response.status).toBe(200)
             const body = await response.json()

--- a/test/integration/worlds-handler.spec.ts
+++ b/test/integration/worlds-handler.spec.ts
@@ -334,22 +334,22 @@ test('WorldsHandler GET /worlds', function ({ components }) {
       })
     })
 
-    describe('and deployer filter is provided', function () {
-      describe('and the deployer is not a valid Ethereum address', function () {
+    describe('and authorized_deployer filter is provided', function () {
+      describe('and the authorized_deployer is not a valid Ethereum address', function () {
         it('should respond with 400', async () => {
           const { localFetch } = components
 
-          const response = await localFetch.fetch('/worlds?deployer=not-a-valid-address')
+          const response = await localFetch.fetch('/worlds?authorized_deployer=not-a-valid-address')
 
           expect(response.status).toBe(400)
           expect(await response.json()).toMatchObject({
             error: 'Bad request',
-            message: expect.stringContaining('Invalid deployer address')
+            message: expect.stringContaining('Invalid authorized_deployer address')
           })
         })
       })
 
-      describe('and the deployer is the owner of some worlds', function () {
+      describe('and the authorized_deployer is the owner of some worlds', function () {
         let ownerAddress: string
 
         beforeEach(async () => {
@@ -359,10 +359,10 @@ test('WorldsHandler GET /worlds', function ({ components }) {
           ownerAddress = metadata!.owner!
         })
 
-        it('should return only worlds where the deployer is owner', async () => {
+        it('should return only worlds where the authorized_deployer is owner', async () => {
           const { localFetch } = components
 
-          const response = await localFetch.fetch(`/worlds?deployer=${ownerAddress}`)
+          const response = await localFetch.fetch(`/worlds?authorized_deployer=${ownerAddress}`)
 
           expect(response.status).toBe(200)
           const body = await response.json()
@@ -374,7 +374,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         })
       })
 
-      describe('and the deployer has deployment permission', function () {
+      describe('and the authorized_deployer has deployment permission', function () {
         let deployerAddress: string
 
         beforeEach(async () => {
@@ -385,10 +385,10 @@ test('WorldsHandler GET /worlds', function ({ components }) {
           await permissions.grantWorldWidePermission(worldName2, 'deployment', [deployerAddress])
         })
 
-        it('should return worlds where the deployer has deployment permission', async () => {
+        it('should return worlds where the authorized_deployer has deployment permission', async () => {
           const { localFetch } = components
 
-          const response = await localFetch.fetch(`/worlds?deployer=${deployerAddress}`)
+          const response = await localFetch.fetch(`/worlds?authorized_deployer=${deployerAddress}`)
 
           expect(response.status).toBe(200)
           const body = await response.json()
@@ -397,7 +397,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         })
       })
 
-      describe('and the deployer is neither owner nor has permission', function () {
+      describe('and the authorized_deployer is neither owner nor has permission', function () {
         let unknownAddress: string
 
         beforeEach(() => {
@@ -407,7 +407,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         it('should return an empty list', async () => {
           const { localFetch } = components
 
-          const response = await localFetch.fetch(`/worlds?deployer=${unknownAddress}`)
+          const response = await localFetch.fetch(`/worlds?authorized_deployer=${unknownAddress}`)
 
           expect(response.status).toBe(200)
           const body = await response.json()


### PR DESCRIPTION
This PR adds the deployer parameter to the `/scenes` and `/worlds` endpoints, making it possible to filter by users that have deployment permissions.

Closes https://github.com/decentraland/core-team/issues/171