### PR TITLE
fix: Build distributable including test directory

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1,9 +1,9 @@
 import { Lifecycle } from '@well-known-components/interfaces'
 import { setupRouter } from './controllers/routes'
-import { AppComponents, GlobalContext, TestComponents } from './types'
+import { AppComponents, GlobalContext } from './types'
 
 // this function wires the business logic (adapters & controllers) with the components (ports)
-export async function main(program: Lifecycle.EntryPointParameters<AppComponents | TestComponents>) {
+export async function main(program: Lifecycle.EntryPointParameters<AppComponents>) {
   const { components, startComponents } = program
   const globalContext: GlobalContext = {
     components

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ import { AccessSetting, IAccessComponent } from './logic/access'
 import { ISocialServiceComponent } from './adapters/social-service'
 import { ICommsComponent } from './logic/comms'
 import { IWorldsComponent } from './logic/worlds'
-import type { IAuthenticatedFetchComponent } from '../test/components/local-auth-fetch'
 
 export type GlobalContext = {
   components: BaseComponents
@@ -487,15 +486,6 @@ export type IWorldCreator = {
 // components used in runtime
 export type AppComponents = BaseComponents & {
   statusChecks: IBaseComponent
-}
-
-// components used in tests
-export type TestComponents = BaseComponents & {
-  // A fetch component that only hits the test server with optional authentication support
-  localFetch: IAuthenticatedFetchComponent
-  worldCreator: IWorldCreator
-  // Mocked version of nameOwnership for testing
-  nameOwnership: jest.Mocked<INameOwnership>
 }
 
 // this type simplifies the typings of http handlers

--- a/test/components.ts
+++ b/test/components.ts
@@ -4,7 +4,7 @@
 import { createRunner } from '@well-known-components/test-helpers'
 
 import { main } from '../src/service'
-import { TestComponents } from '../src/types'
+import { TestComponents } from './types'
 import { initComponents as originalInitComponents } from '../src/components'
 import { createMockNameSubGraph } from './mocks/name-subgraph-mock'
 import { createMockNamePermissionChecker } from './mocks/dcl-name-checker-mock'
@@ -48,7 +48,12 @@ import { createMockSocialService } from './mocks/social-service-mock'
  * State is persistent within the steps of the test.
  */
 export const test = createRunner<TestComponents>({
-  main,
+  // Cast main since TestComponents extends AppComponents but TypeScript's
+  // contravariance rules for function parameters require an explicit cast
+  main: main as unknown as (program: {
+    components: TestComponents
+    startComponents: () => Promise<void>
+  }) => Promise<void>,
   initComponents
 })
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,11 @@
+import { AppComponents, INameOwnership, IWorldCreator } from '../src/types'
+import { IAuthenticatedFetchComponent } from './components/local-auth-fetch'
+
+// components used in tests
+export type TestComponents = AppComponents & {
+  // A fetch component that only hits the test server with optional authentication support
+  localFetch: IAuthenticatedFetchComponent
+  worldCreator: IWorldCreator
+  // Mocked version of nameOwnership for testing
+  nameOwnership: jest.Mocked<INameOwnership>
+}


### PR DESCRIPTION
This PR removes the types consumed from the `/test` directory so the build process does not include the directory in the build output directory.