### PR TITLE
feat: add HTTP range request support for content files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@dcl/catalyst-api-specs": "^3.3.0",
     "@dcl/catalyst-contracts": "^4.4.2",
-    "@dcl/catalyst-storage": "^4.3.1",
+    "@dcl/catalyst-storage": "^4.5.1",
     "@dcl/crypto": "^3.4.5",
     "@dcl/hashing": "^3.0.4",
     "@dcl/http-commons": "^1.0.0",

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -109,6 +109,7 @@ export async function getContentFile(
     return retrieveFullContent(ctx.components.storage, ctx.params.hashId)
   }
 
+  // start and end are inclusive byte offsets, matching RFC 7233 and catalyst-storage convention
   const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
   if (!file) return { status: 404 }
 

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -109,8 +109,22 @@ export async function getContentFile(
     return retrieveFullContent(ctx.components.storage, ctx.params.hashId)
   }
 
-  // start and end are inclusive byte offsets, matching RFC 7233 and catalyst-storage convention
-  const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
+  // start and end are inclusive byte offsets, matching RFC 7233 and catalyst-storage convention.
+  // retrieve may throw RangeError if the file size changed between fileInfo and retrieve.
+  let file: Awaited<ReturnType<IContentStorageComponent['retrieve']>>
+  try {
+    file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return {
+        status: 416,
+        headers: {
+          'Content-Range': `bytes */${fileInfo.size}`
+        }
+      }
+    }
+    throw error
+  }
   if (!file) return { status: 404 }
 
   return {

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -112,16 +112,11 @@ export async function getContentFile(
   const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
   if (!file) return { status: 404 }
 
-  const contentLength = range.end - range.start + 1
   return {
     status: 206,
     headers: {
-      'Content-Type': 'application/octet-stream',
-      ETag: JSON.stringify(ctx.params.hashId),
-      'Access-Control-Expose-Headers': EXPOSED_HEADERS,
-      'Accept-Ranges': 'bytes',
-      'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable',
-      'Content-Length': contentLength.toString(),
+      ...contentItemHeaders(file, ctx.params.hashId),
+      'Content-Length': (range.end - range.start + 1).toString(),
       'Content-Range': `bytes ${range.start}-${range.end}/${fileInfo.size}`
     },
     body: await file.asRawStream()

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -17,11 +17,16 @@ function contentItemHeaders(content: ContentItem, hashId: string) {
   } else {
     ret['Accept-Ranges'] = 'bytes'
   }
-  if (content.size) {
+  if (content.size !== null) {
     ret['Content-Length'] = content.size.toString()
   }
   return ret
 }
+
+export type RangeParseResult =
+  | { kind: 'ok'; start: number; end: number }
+  | { kind: 'unsupported' }
+  | { kind: 'invalid' }
 
 /**
  * Parses a Range header value against a known file size.
@@ -29,16 +34,17 @@ function contentItemHeaders(content: ContentItem, hashId: string) {
  *   bytes=START-END
  *   bytes=START-
  *   bytes=-SUFFIX
- * Returns null for unsupported formats (e.g. multi-range).
+ * Returns { kind: 'unsupported' } for formats we don't handle (e.g. multi-range, non-bytes unit).
+ * Returns { kind: 'invalid' } for syntactically valid but unsatisfiable ranges.
  */
-export function parseRangeHeader(header: string, fileSize: number): { start: number; end: number } | null {
+export function parseRangeHeader(header: string, fileSize: number): RangeParseResult {
   const match = header.match(/^bytes=(\d*)-(\d*)$/)
-  if (!match) return null
+  if (!match) return { kind: 'unsupported' }
 
   const hasStart = match[1] !== ''
   const hasEnd = match[2] !== ''
 
-  if (!hasStart && !hasEnd) return null
+  if (!hasStart && !hasEnd) return { kind: 'unsupported' }
 
   let start: number
   let end: number
@@ -46,7 +52,7 @@ export function parseRangeHeader(header: string, fileSize: number): { start: num
   if (!hasStart) {
     // suffix range: bytes=-N (last N bytes)
     const suffix = parseInt(match[2], 10)
-    if (suffix === 0) return null
+    if (suffix === 0) return { kind: 'invalid' }
     start = Math.max(0, fileSize - suffix)
     end = fileSize - 1
   } else {
@@ -54,9 +60,9 @@ export function parseRangeHeader(header: string, fileSize: number): { start: num
     end = hasEnd ? parseInt(match[2], 10) : fileSize - 1
   }
 
-  if (start >= fileSize || end < start) return null
+  if (start >= fileSize || end < start) return { kind: 'invalid' }
 
-  return { start, end: Math.min(end, fileSize - 1) }
+  return { kind: 'ok', start, end: Math.min(end, fileSize - 1) }
 }
 
 export async function getContentFile(
@@ -78,7 +84,8 @@ export async function getContentFile(
     }
 
     const range = parseRangeHeader(rangeHeader, fileInfo.size)
-    if (!range) {
+
+    if (range.kind === 'invalid') {
       return {
         status: 416,
         headers: {
@@ -87,7 +94,14 @@ export async function getContentFile(
       }
     }
 
-    const file = await ctx.components.storage.retrieve(ctx.params.hashId, range)
+    // Unsupported range format (e.g. multi-range): ignore and serve full content per RFC 7233
+    if (range.kind === 'unsupported') {
+      const file = await ctx.components.storage.retrieve(ctx.params.hashId)
+      if (!file) return { status: 404 }
+      return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId), body: await file.asRawStream() }
+    }
+
+    const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
     if (!file) return { status: 404 }
 
     const contentLength = range.end - range.start + 1

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -1,7 +1,7 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { IPFSv2 } from '@dcl/schemas'
 import { HandlerContextWithPath } from '../../types'
-import { ContentItem } from '@dcl/catalyst-storage'
+import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
 
 const EXPOSED_HEADERS = 'ETag, Accept-Ranges, Content-Range'
 
@@ -65,6 +65,15 @@ export function parseRangeHeader(header: string, fileSize: number): RangeParseRe
   return { kind: 'ok', start, end: Math.min(end, fileSize - 1) }
 }
 
+async function retrieveFullContent(
+  storage: Pick<IContentStorageComponent, 'retrieve'>,
+  hashId: string
+): Promise<IHttpServerComponent.IResponse> {
+  const file = await storage.retrieve(hashId)
+  if (!file) return { status: 404 }
+  return { status: 200, headers: contentItemHeaders(file, hashId), body: await file.asRawStream() }
+}
+
 export async function getContentFile(
   ctx: HandlerContextWithPath<'storage', '/contents/:hashId'>
 ): Promise<IHttpServerComponent.IResponse> {
@@ -72,59 +81,51 @@ export async function getContentFile(
 
   const rangeHeader = ctx.request.headers.get('range')
 
-  if (rangeHeader) {
-    const fileInfo = await ctx.components.storage.fileInfo(ctx.params.hashId)
-    if (!fileInfo) return { status: 404 }
+  if (!rangeHeader) {
+    return retrieveFullContent(ctx.components.storage, ctx.params.hashId)
+  }
 
-    // Cannot serve byte ranges on compressed content
-    if (fileInfo.encoding || fileInfo.size === null) {
-      const file = await ctx.components.storage.retrieve(ctx.params.hashId)
-      if (!file) return { status: 404 }
-      return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId), body: await file.asRawStream() }
-    }
+  const fileInfo = await ctx.components.storage.fileInfo(ctx.params.hashId)
+  if (!fileInfo) return { status: 404 }
 
-    const range = parseRangeHeader(rangeHeader, fileInfo.size)
+  // Cannot serve byte ranges on compressed content or when size is unknown
+  if (fileInfo.encoding || fileInfo.size === null) {
+    return retrieveFullContent(ctx.components.storage, ctx.params.hashId)
+  }
 
-    if (range.kind === 'invalid') {
-      return {
-        status: 416,
-        headers: {
-          'Content-Range': `bytes */${fileInfo.size}`
-        }
-      }
-    }
+  const range = parseRangeHeader(rangeHeader, fileInfo.size)
 
-    // Unsupported range format (e.g. multi-range): ignore and serve full content per RFC 7233
-    if (range.kind === 'unsupported') {
-      const file = await ctx.components.storage.retrieve(ctx.params.hashId)
-      if (!file) return { status: 404 }
-      return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId), body: await file.asRawStream() }
-    }
-
-    const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
-    if (!file) return { status: 404 }
-
-    const contentLength = range.end - range.start + 1
+  if (range.kind === 'invalid') {
     return {
-      status: 206,
+      status: 416,
       headers: {
-        'Content-Type': 'application/octet-stream',
-        ETag: JSON.stringify(ctx.params.hashId),
-        'Access-Control-Expose-Headers': EXPOSED_HEADERS,
-        'Accept-Ranges': 'bytes',
-        'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable',
-        'Content-Length': contentLength.toString(),
-        'Content-Range': `bytes ${range.start}-${range.end}/${fileInfo.size}`
-      },
-      body: await file.asRawStream()
+        'Content-Range': `bytes */${fileInfo.size}`
+      }
     }
   }
 
-  const file = await ctx.components.storage.retrieve(ctx.params.hashId)
+  // Unsupported range format (e.g. multi-range): ignore and serve full content per RFC 7233
+  if (range.kind === 'unsupported') {
+    return retrieveFullContent(ctx.components.storage, ctx.params.hashId)
+  }
 
+  const file = await ctx.components.storage.retrieve(ctx.params.hashId, { start: range.start, end: range.end })
   if (!file) return { status: 404 }
 
-  return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId), body: await file.asRawStream() }
+  const contentLength = range.end - range.start + 1
+  return {
+    status: 206,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      ETag: JSON.stringify(ctx.params.hashId),
+      'Access-Control-Expose-Headers': EXPOSED_HEADERS,
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable',
+      'Content-Length': contentLength.toString(),
+      'Content-Range': `bytes ${range.start}-${range.end}/${fileInfo.size}`
+    },
+    body: await file.asRawStream()
+  }
 }
 
 export async function headContentFile(

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -3,15 +3,19 @@ import { IPFSv2 } from '@dcl/schemas'
 import { HandlerContextWithPath } from '../../types'
 import { ContentItem } from '@dcl/catalyst-storage'
 
+const EXPOSED_HEADERS = 'ETag, Accept-Ranges, Content-Range'
+
 function contentItemHeaders(content: ContentItem, hashId: string) {
   const ret: Record<string, string> = {
     'Content-Type': 'application/octet-stream',
     ETag: JSON.stringify(hashId), // by spec, the ETag must be a double-quoted string
-    'Access-Control-Expose-Headers': 'ETag',
+    'Access-Control-Expose-Headers': EXPOSED_HEADERS,
     'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable'
   }
   if (content.encoding) {
     ret['Content-Encoding'] = content.encoding
+  } else {
+    ret['Accept-Ranges'] = 'bytes'
   }
   if (content.size) {
     ret['Content-Length'] = content.size.toString()
@@ -19,10 +23,88 @@ function contentItemHeaders(content: ContentItem, hashId: string) {
   return ret
 }
 
+/**
+ * Parses a Range header value against a known file size.
+ * Supports:
+ *   bytes=START-END
+ *   bytes=START-
+ *   bytes=-SUFFIX
+ * Returns null for unsupported formats (e.g. multi-range).
+ */
+export function parseRangeHeader(header: string, fileSize: number): { start: number; end: number } | null {
+  const match = header.match(/^bytes=(\d*)-(\d*)$/)
+  if (!match) return null
+
+  const hasStart = match[1] !== ''
+  const hasEnd = match[2] !== ''
+
+  if (!hasStart && !hasEnd) return null
+
+  let start: number
+  let end: number
+
+  if (!hasStart) {
+    // suffix range: bytes=-N (last N bytes)
+    const suffix = parseInt(match[2], 10)
+    if (suffix === 0) return null
+    start = Math.max(0, fileSize - suffix)
+    end = fileSize - 1
+  } else {
+    start = parseInt(match[1], 10)
+    end = hasEnd ? parseInt(match[2], 10) : fileSize - 1
+  }
+
+  if (start >= fileSize || end < start) return null
+
+  return { start, end: Math.min(end, fileSize - 1) }
+}
+
 export async function getContentFile(
   ctx: HandlerContextWithPath<'storage', '/contents/:hashId'>
 ): Promise<IHttpServerComponent.IResponse> {
   if (!IPFSv2.validate(ctx.params.hashId)) return { status: 400 }
+
+  const rangeHeader = ctx.request.headers.get('range')
+
+  if (rangeHeader) {
+    const fileInfo = await ctx.components.storage.fileInfo(ctx.params.hashId)
+    if (!fileInfo) return { status: 404 }
+
+    // Cannot serve byte ranges on compressed content
+    if (fileInfo.encoding || fileInfo.size === null) {
+      const file = await ctx.components.storage.retrieve(ctx.params.hashId)
+      if (!file) return { status: 404 }
+      return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId), body: await file.asRawStream() }
+    }
+
+    const range = parseRangeHeader(rangeHeader, fileInfo.size)
+    if (!range) {
+      return {
+        status: 416,
+        headers: {
+          'Content-Range': `bytes */${fileInfo.size}`
+        }
+      }
+    }
+
+    const file = await ctx.components.storage.retrieve(ctx.params.hashId, range)
+    if (!file) return { status: 404 }
+
+    const contentLength = range.end - range.start + 1
+    return {
+      status: 206,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        ETag: JSON.stringify(ctx.params.hashId),
+        'Access-Control-Expose-Headers': EXPOSED_HEADERS,
+        'Accept-Ranges': 'bytes',
+        'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable',
+        'Content-Length': contentLength.toString(),
+        'Content-Range': `bytes ${range.start}-${range.end}/${fileInfo.size}`
+      },
+      body: await file.asRawStream()
+    }
+  }
 
   const file = await ctx.components.storage.retrieve(ctx.params.hashId)
 

--- a/test/integration/get-endpoints.spec.ts
+++ b/test/integration/get-endpoints.spec.ts
@@ -118,9 +118,7 @@ test('consume get endpoints', function ({ components }) {
       })
 
       it('should include the Content-Range header', () => {
-        expect(response.headers.get('content-range')).toEqual(
-          `bytes 7-${contentBody.length - 1}/${contentBody.length}`
-        )
+        expect(response.headers.get('content-range')).toEqual(`bytes 7-${contentBody.length - 1}/${contentBody.length}`)
       })
     })
 
@@ -188,12 +186,9 @@ test('consume get endpoints', function ({ components }) {
 
       beforeEach(async () => {
         const { localFetch } = components
-        response = await localFetch.fetch(
-          '/contents/bafybeictjyqjlkgybfckczpuqlqo7xfhho3jpnep4wesw3ivaeeuqugc2y',
-          {
-            headers: { Range: 'bytes=0-10' }
-          }
-        )
+        response = await localFetch.fetch('/contents/bafybeictjyqjlkgybfckczpuqlqo7xfhho3jpnep4wesw3ivaeeuqugc2y', {
+          headers: { Range: 'bytes=0-10' }
+        })
       })
 
       it('should respond with 404', () => {

--- a/test/integration/get-endpoints.spec.ts
+++ b/test/integration/get-endpoints.spec.ts
@@ -195,5 +195,36 @@ test('consume get endpoints', function ({ components }) {
         expect(response.status).toEqual(404)
       })
     })
+
+    describe('when requesting with an invalid hash and a Range header', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch('/contents/invalid-hash', {
+          headers: { Range: 'bytes=0-10' }
+        })
+      })
+
+      it('should respond with 400', () => {
+        expect(response.status).toEqual(400)
+      })
+    })
+
+    describe('when requesting with a multi-range header', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`, {
+          headers: { Range: 'bytes=0-4,7-11' }
+        })
+      })
+
+      it('should fall back to 200 with the full content', async () => {
+        expect(response.status).toEqual(200)
+        expect(await response.text()).toEqual(contentBody)
+      })
+    })
   })
 })

--- a/test/integration/get-endpoints.spec.ts
+++ b/test/integration/get-endpoints.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '../components'
 import { Entity } from '@dcl/schemas'
+import { bufferToStream } from '@dcl/catalyst-storage'
 
 test('consume get endpoints', function ({ components }) {
   let entity: Entity
@@ -56,6 +57,148 @@ test('consume get endpoints', function ({ components }) {
         rooms: 1,
         users: 2
       }
+    })
+  })
+
+  describe('range requests', () => {
+    const contentHash = 'bafkreiahsvnr4x4rnskhkwfbnbplkbqhzb3xagdwpyfy44lgcndmhyizde'
+    const contentBody = 'Hello, World! This is test content for range requests.'
+
+    beforeEach(async () => {
+      const { storage } = components
+      await storage.storeStream(contentHash, bufferToStream(Buffer.from(contentBody)))
+    })
+
+    afterEach(async () => {
+      const { storage } = components
+      await storage.delete([contentHash])
+    })
+
+    describe('when requesting a valid byte range', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`, {
+          headers: { Range: 'bytes=0-4' }
+        })
+      })
+
+      it('should respond with 206 and the partial content', async () => {
+        expect(response.status).toEqual(206)
+        expect(await response.text()).toEqual('Hello')
+      })
+
+      it('should include the Content-Range header', () => {
+        expect(response.headers.get('content-range')).toEqual(`bytes 0-4/${contentBody.length}`)
+      })
+
+      it('should include the correct Content-Length', () => {
+        expect(response.headers.get('content-length')).toEqual('5')
+      })
+
+      it('should include Accept-Ranges header', () => {
+        expect(response.headers.get('accept-ranges')).toEqual('bytes')
+      })
+    })
+
+    describe('when requesting a range from an offset to the end', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`, {
+          headers: { Range: 'bytes=7-' }
+        })
+      })
+
+      it('should respond with 206 and the content from offset to end', async () => {
+        expect(response.status).toEqual(206)
+        expect(await response.text()).toEqual(contentBody.slice(7))
+      })
+
+      it('should include the Content-Range header', () => {
+        expect(response.headers.get('content-range')).toEqual(
+          `bytes 7-${contentBody.length - 1}/${contentBody.length}`
+        )
+      })
+    })
+
+    describe('when requesting a suffix range', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`, {
+          headers: { Range: 'bytes=-9' }
+        })
+      })
+
+      it('should respond with 206 and the last N bytes', async () => {
+        expect(response.status).toEqual(206)
+        expect(await response.text()).toEqual('requests.')
+      })
+
+      it('should include the Content-Range header', () => {
+        expect(response.headers.get('content-range')).toEqual(
+          `bytes ${contentBody.length - 9}-${contentBody.length - 1}/${contentBody.length}`
+        )
+      })
+    })
+
+    describe('when requesting an out-of-bounds range', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`, {
+          headers: { Range: `bytes=${contentBody.length + 10}-` }
+        })
+      })
+
+      it('should respond with 416 Range Not Satisfiable', () => {
+        expect(response.status).toEqual(416)
+      })
+
+      it('should include the Content-Range header with the file size', () => {
+        expect(response.headers.get('content-range')).toEqual(`bytes */${contentBody.length}`)
+      })
+    })
+
+    describe('when requesting content without a Range header', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/contents/${contentHash}`)
+      })
+
+      it('should respond with 200 and the full content', async () => {
+        expect(response.status).toEqual(200)
+        expect(await response.text()).toEqual(contentBody)
+      })
+
+      it('should include Accept-Ranges header', () => {
+        expect(response.headers.get('accept-ranges')).toEqual('bytes')
+      })
+    })
+
+    describe('when requesting a non-existent file with a Range header', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(
+          '/contents/bafybeictjyqjlkgybfckczpuqlqo7xfhho3jpnep4wesw3ivaeeuqugc2y',
+          {
+            headers: { Range: 'bytes=0-10' }
+          }
+        )
+      })
+
+      it('should respond with 404', () => {
+        expect(response.status).toEqual(404)
+      })
     })
   })
 })

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -1,4 +1,8 @@
-import { parseRangeHeader } from '../../src/controllers/handlers/content-file-handler'
+import { Readable } from 'stream'
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { getContentFile, parseRangeHeader } from '../../src/controllers/handlers/content-file-handler'
+import { HandlerContextWithPath } from '../../src/types'
+import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
 
 describe('parseRangeHeader', () => {
   const fileSize = 1000
@@ -11,7 +15,7 @@ describe('parseRangeHeader', () => {
     })
 
     it('should return the parsed start and end', () => {
-      expect(result).toEqual({ start: 0, end: 499 })
+      expect(result).toEqual({ kind: 'ok', start: 0, end: 499 })
     })
   })
 
@@ -23,7 +27,7 @@ describe('parseRangeHeader', () => {
     })
 
     it('should default end to the last byte', () => {
-      expect(result).toEqual({ start: 500, end: 999 })
+      expect(result).toEqual({ kind: 'ok', start: 500, end: 999 })
     })
   })
 
@@ -35,7 +39,7 @@ describe('parseRangeHeader', () => {
     })
 
     it('should return the last N bytes', () => {
-      expect(result).toEqual({ start: 800, end: 999 })
+      expect(result).toEqual({ kind: 'ok', start: 800, end: 999 })
     })
   })
 
@@ -47,7 +51,7 @@ describe('parseRangeHeader', () => {
     })
 
     it('should clamp start to 0', () => {
-      expect(result).toEqual({ start: 0, end: 999 })
+      expect(result).toEqual({ kind: 'ok', start: 0, end: 999 })
     })
   })
 
@@ -58,8 +62,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('bytes=-0', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return invalid', () => {
+      expect(result).toEqual({ kind: 'invalid' })
     })
   })
 
@@ -71,7 +75,7 @@ describe('parseRangeHeader', () => {
     })
 
     it('should clamp end to the last byte', () => {
-      expect(result).toEqual({ start: 900, end: 999 })
+      expect(result).toEqual({ kind: 'ok', start: 900, end: 999 })
     })
   })
 
@@ -82,8 +86,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('bytes=1000-', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return invalid', () => {
+      expect(result).toEqual({ kind: 'invalid' })
     })
   })
 
@@ -94,8 +98,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('bytes=500-100', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return invalid', () => {
+      expect(result).toEqual({ kind: 'invalid' })
     })
   })
 
@@ -106,8 +110,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('bytes=0-100,200-300', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return unsupported', () => {
+      expect(result).toEqual({ kind: 'unsupported' })
     })
   })
 
@@ -118,8 +122,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('items=0-100', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return unsupported', () => {
+      expect(result).toEqual({ kind: 'unsupported' })
     })
   })
 
@@ -130,8 +134,8 @@ describe('parseRangeHeader', () => {
       result = parseRangeHeader('bytes=-', fileSize)
     })
 
-    it('should return null', () => {
-      expect(result).toBeNull()
+    it('should return unsupported', () => {
+      expect(result).toEqual({ kind: 'unsupported' })
     })
   })
 
@@ -143,7 +147,116 @@ describe('parseRangeHeader', () => {
     })
 
     it('should return a single-byte range', () => {
-      expect(result).toEqual({ start: 0, end: 0 })
+      expect(result).toEqual({ kind: 'ok', start: 0, end: 0 })
+    })
+  })
+
+  describe('when the file size is zero', () => {
+    const zeroFileSize = 0
+
+    describe('and the range requests from the start', () => {
+      let result: ReturnType<typeof parseRangeHeader>
+
+      beforeEach(() => {
+        result = parseRangeHeader('bytes=0-', zeroFileSize)
+      })
+
+      it('should return invalid', () => {
+        expect(result).toEqual({ kind: 'invalid' })
+      })
+    })
+
+    describe('and the range is a suffix', () => {
+      let result: ReturnType<typeof parseRangeHeader>
+
+      beforeEach(() => {
+        result = parseRangeHeader('bytes=-5', zeroFileSize)
+      })
+
+      it('should return invalid', () => {
+        expect(result).toEqual({ kind: 'invalid' })
+      })
+    })
+  })
+})
+
+describe('getContentFile', () => {
+  const hashId = 'bafkreiahsvnr4x4rnskhkwfbnbplkbqhzb3xagdwpyfy44lgcndmhyizde'
+  const fileContent = Buffer.from('test content')
+
+  function createContentItem(overrides: Partial<ContentItem> = {}): ContentItem {
+    return {
+      encoding: null,
+      size: fileContent.length,
+      contentSize: fileContent.length,
+      asStream: jest.fn().mockResolvedValue(Readable.from(fileContent)),
+      asRawStream: jest.fn().mockResolvedValue(Readable.from(fileContent)),
+      ...overrides
+    }
+  }
+
+  function createContext(
+    storage: Partial<IContentStorageComponent>,
+    rangeHeader?: string
+  ): HandlerContextWithPath<'storage', '/contents/:hashId'> {
+    const headers = new Headers()
+    if (rangeHeader) {
+      headers.set('range', rangeHeader)
+    }
+
+    return {
+      url: new URL(`http://localhost/contents/${hashId}`),
+      params: { hashId },
+      request: { headers } as unknown as IHttpServerComponent.IRequest,
+      components: { storage: storage as IContentStorageComponent }
+    }
+  }
+
+  describe('when the file has compressed encoding and a Range header is sent', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      const compressedItem = createContentItem({ encoding: 'gzip' })
+      storageMock = {
+        fileInfo: jest.fn().mockResolvedValue({ encoding: 'gzip', size: 100, contentSize: 200 }),
+        retrieve: jest.fn().mockResolvedValue(compressedItem)
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=0-10'))
+    })
+
+    it('should fall back to a 200 response with full content', () => {
+      expect(response.status).toEqual(200)
+    })
+
+    it('should retrieve the full file without a range', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(hashId)
+    })
+
+    it('should not advertise Accept-Ranges', () => {
+      expect(response.headers!['Accept-Ranges']).toBeUndefined()
+    })
+  })
+
+  describe('when the file size is null and a Range header is sent', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      const item = createContentItem({ size: null })
+      storageMock = {
+        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: null, contentSize: null }),
+        retrieve: jest.fn().mockResolvedValue(item)
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=0-10'))
+    })
+
+    it('should fall back to a 200 response with full content', () => {
+      expect(response.status).toEqual(200)
+    })
+
+    it('should retrieve the full file without a range', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(hashId)
     })
   })
 })

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -259,4 +259,89 @@ describe('getContentFile', () => {
       expect(storageMock.retrieve).toHaveBeenCalledWith(hashId)
     })
   })
+
+  describe('when a valid Range header is sent', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      const rangedItem = createContentItem({ size: 5 })
+      storageMock = {
+        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        retrieve: jest.fn().mockResolvedValue(rangedItem)
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=0-4'))
+    })
+
+    it('should respond with 206', () => {
+      expect(response.status).toEqual(206)
+    })
+
+    it('should retrieve with the correct range', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(hashId, { start: 0, end: 4 })
+    })
+
+    it('should include the Content-Range header with the total file size', () => {
+      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(
+        `bytes 0-4/${fileContent.length}`
+      )
+    })
+
+    it('should set Content-Length to the range size', () => {
+      expect((response.headers as Record<string, string>)['Content-Length']).toEqual('5')
+    })
+  })
+
+  describe('when an invalid Range header is sent', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      storageMock = {
+        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        retrieve: jest.fn()
+      }
+      response = await getContentFile(createContext(storageMock, `bytes=${fileContent.length + 10}-`))
+    })
+
+    it('should respond with 416', () => {
+      expect(response.status).toEqual(416)
+    })
+
+    it('should include the Content-Range header with the file size', () => {
+      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(
+        `bytes */${fileContent.length}`
+      )
+    })
+
+    it('should not call retrieve', () => {
+      expect(storageMock.retrieve).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when no Range header is sent', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      const item = createContentItem()
+      storageMock = {
+        fileInfo: jest.fn(),
+        retrieve: jest.fn().mockResolvedValue(item)
+      }
+      response = await getContentFile(createContext(storageMock))
+    })
+
+    it('should respond with 200', () => {
+      expect(response.status).toEqual(200)
+    })
+
+    it('should retrieve without a range', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(hashId)
+    })
+
+    it('should not call fileInfo', () => {
+      expect(storageMock.fileInfo).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -319,6 +319,24 @@ describe('getContentFile', () => {
     })
   })
 
+  describe('when fileInfo succeeds but retrieve returns null', () => {
+    let response: IHttpServerComponent.IResponse
+
+    beforeEach(async () => {
+      const storageMock: Partial<IContentStorageComponent> = {
+        fileInfo: jest
+          .fn()
+          .mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        retrieve: jest.fn().mockResolvedValue(undefined)
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=0-4'))
+    })
+
+    it('should respond with 404', () => {
+      expect(response.status).toEqual(404)
+    })
+  })
+
   describe('when no Range header is sent', () => {
     let response: IHttpServerComponent.IResponse
     let storageMock: Partial<IContentStorageComponent>

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -319,6 +319,45 @@ describe('getContentFile', () => {
     })
   })
 
+  describe('when retrieve throws a RangeError', () => {
+    let response: IHttpServerComponent.IResponse
+
+    beforeEach(async () => {
+      const storageMock: Partial<IContentStorageComponent> = {
+        fileInfo: jest
+          .fn()
+          .mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        retrieve: jest.fn().mockRejectedValue(new RangeError('Range start 0 exceeds size 0'))
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=0-4'))
+    })
+
+    it('should respond with 416', () => {
+      expect(response.status).toEqual(416)
+    })
+
+    it('should include the Content-Range header with the file size', () => {
+      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(`bytes */${fileContent.length}`)
+    })
+  })
+
+  describe('when retrieve throws a non-RangeError', () => {
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(() => {
+      storageMock = {
+        fileInfo: jest
+          .fn()
+          .mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        retrieve: jest.fn().mockRejectedValue(new Error('connection lost'))
+      }
+    })
+
+    it('should re-throw the error', async () => {
+      await expect(getContentFile(createContext(storageMock, 'bytes=0-4'))).rejects.toThrow('connection lost')
+    })
+  })
+
   describe('when fileInfo succeeds but retrieve returns null', () => {
     let response: IHttpServerComponent.IResponse
 

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -1,0 +1,149 @@
+import { parseRangeHeader } from '../../src/controllers/handlers/content-file-handler'
+
+describe('parseRangeHeader', () => {
+  const fileSize = 1000
+
+  describe('when the range has start and end', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=0-499', fileSize)
+    })
+
+    it('should return the parsed start and end', () => {
+      expect(result).toEqual({ start: 0, end: 499 })
+    })
+  })
+
+  describe('when the range has only a start', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=500-', fileSize)
+    })
+
+    it('should default end to the last byte', () => {
+      expect(result).toEqual({ start: 500, end: 999 })
+    })
+  })
+
+  describe('when the range is a suffix range', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=-200', fileSize)
+    })
+
+    it('should return the last N bytes', () => {
+      expect(result).toEqual({ start: 800, end: 999 })
+    })
+  })
+
+  describe('when the suffix range exceeds file size', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=-2000', fileSize)
+    })
+
+    it('should clamp start to 0', () => {
+      expect(result).toEqual({ start: 0, end: 999 })
+    })
+  })
+
+  describe('when the suffix is zero', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=-0', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when the end exceeds file size', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=900-1500', fileSize)
+    })
+
+    it('should clamp end to the last byte', () => {
+      expect(result).toEqual({ start: 900, end: 999 })
+    })
+  })
+
+  describe('when start equals file size', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=1000-', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when start is greater than end', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=500-100', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when the header is a multi-range request', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=0-100,200-300', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when the header has an invalid unit', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('items=0-100', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when the header has no start or end', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=-', fileSize)
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when requesting the first byte', () => {
+    let result: ReturnType<typeof parseRangeHeader>
+
+    beforeEach(() => {
+      result = parseRangeHeader('bytes=0-0', fileSize)
+    })
+
+    it('should return a single-byte range', () => {
+      expect(result).toEqual({ start: 0, end: 0 })
+    })
+  })
+})

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -267,7 +267,9 @@ describe('getContentFile', () => {
     beforeEach(async () => {
       const rangedItem = createContentItem({ size: 5 })
       storageMock = {
-        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        fileInfo: jest
+          .fn()
+          .mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
         retrieve: jest.fn().mockResolvedValue(rangedItem)
       }
       response = await getContentFile(createContext(storageMock, 'bytes=0-4'))
@@ -282,9 +284,7 @@ describe('getContentFile', () => {
     })
 
     it('should include the Content-Range header with the total file size', () => {
-      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(
-        `bytes 0-4/${fileContent.length}`
-      )
+      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(`bytes 0-4/${fileContent.length}`)
     })
 
     it('should set Content-Length to the range size', () => {
@@ -298,7 +298,9 @@ describe('getContentFile', () => {
 
     beforeEach(async () => {
       storageMock = {
-        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
+        fileInfo: jest
+          .fn()
+          .mockResolvedValue({ encoding: null, size: fileContent.length, contentSize: fileContent.length }),
         retrieve: jest.fn()
       }
       response = await getContentFile(createContext(storageMock, `bytes=${fileContent.length + 10}-`))
@@ -309,9 +311,7 @@ describe('getContentFile', () => {
     })
 
     it('should include the Content-Range header with the file size', () => {
-      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(
-        `bytes */${fileContent.length}`
-      )
+      expect((response.headers as Record<string, string>)['Content-Range']).toEqual(`bytes */${fileContent.length}`)
     })
 
     it('should not call retrieve', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+"@aws-crypto/sha256-js@^5.2.0", "@aws-crypto/sha256-js@5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz"
   integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
@@ -511,7 +511,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -770,6 +770,11 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@borewit/text-codec@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz"
+  integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
+
 "@bufbuild/protobuf@^1.10.0", "@bufbuild/protobuf@^1.10.1":
   version "1.10.1"
   resolved "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz"
@@ -794,16 +799,16 @@
   resolved "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.4.2.tgz"
   integrity sha512-gJZo3IB8U+jhBJWR0DgoLS+zaUDIb/u79e7Rp+MEM78uH3bvC19S3Dd8lxWEbPXNKlCB0saUptfK/Buw0c1y2Q==
 
-"@dcl/catalyst-storage@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/@dcl/catalyst-storage/-/catalyst-storage-4.3.1.tgz"
-  integrity sha512-6CXKFsS2I0cDX7fvL2TsXj1r2CzeOoSpns6NMvQxj0W1/W4LXqXLXz3XgDtfLy3EoHYJMTBXaJfmU07mZ0MyCQ==
+"@dcl/catalyst-storage@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/@dcl/catalyst-storage/-/catalyst-storage-4.5.1.tgz"
+  integrity sha512-hjZbkQIpaA1a0K1m7Q0l4kR49GxDZ+H7sl1m+Hx3qP9wVP0sZVMf4vMzuasww2gtUwJI1PKnW8fkY5wKWuxljA==
   dependencies:
     "@well-known-components/interfaces" "^1.1.1"
     aws-sdk "^2.1426.0"
     aws-sdk-client-mock "^3.0.0"
     destroy "^1.2.0"
-    file-type "15"
+    file-type "^21.1.1"
 
 "@dcl/core-commons@0.6.0":
   version "0.6.0"
@@ -934,6 +939,16 @@
     ajv "^8.17.1"
     ajv-formats "^3.0.1"
 
+"@dcl/schemas@*", "@dcl/schemas@^26.1.0":
+  version "26.1.0"
+  resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.1.0.tgz"
+  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
+
 "@dcl/schemas@^18.0.0":
   version "18.8.0"
   resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-18.8.0.tgz"
@@ -948,16 +963,6 @@
   version "23.1.0"
   resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-23.1.0.tgz"
   integrity sha512-2+Sp4OrUKyGxEe1nLMuLtEmNwLThGUDei0QqXzurkQMkhQdJvB1viS4UW86Wia7AelmCzBewSLU6to8CgQ8UEw==
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
-    mitt "^3.0.1"
-
-"@dcl/schemas@^26.1.0":
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-26.1.0.tgz#07a08df2e40450f4540fd4c5e7fb5de46348d5b2"
-  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
@@ -990,28 +995,6 @@
     "@aws-sdk/client-sqs" "^3.956.0"
     "@dcl/core-commons" "0.6.0"
     "@well-known-components/interfaces" "^1.5.2"
-
-"@emnapi/core@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
-  integrity sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.1"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
-  integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
-  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
-  dependencies:
-    tslib "^2.4.0"
 
 "@emotion/is-prop-valid@1.4.0":
   version "1.4.0"
@@ -1281,7 +1264,7 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.7.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
   integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
@@ -1302,7 +1285,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.6.3":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -1340,14 +1323,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
@@ -1355,6 +1330,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jsep-plugin/assignment@^1.3.0":
   version "1.3.0"
@@ -1388,29 +1371,20 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@napi-rs/wasm-runtime@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
-  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@tybys/wasm-util" "^0.10.0"
-
-"@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
+"@noble/hashes@~1.2.0", "@noble/hashes@1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
-
-"@noble/secp256k1@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz"
-  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@noble/secp256k1@~1.7.0":
   version "1.7.2"
   resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz"
   integrity sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==
+
+"@noble/secp256k1@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1420,7 +1394,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1445,7 +1419,7 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api@1.9.0", "@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.4.0":
+"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.4.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0", "@opentelemetry/api@>=1.4.0 <1.10.0", "@opentelemetry/api@1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -1622,7 +1596,7 @@
   resolved "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz"
   integrity sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==
 
-"@redis/client@5.10.0":
+"@redis/client@^5.10.0", "@redis/client@5.10.0":
   version "5.10.0"
   resolved "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz"
   integrity sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==
@@ -1644,16 +1618,6 @@
   resolved "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz"
   integrity sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==
 
-"@redocly/ajv@8.11.2":
-  version "8.11.2"
-  resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz"
-  integrity sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js-replace "^1.0.1"
-
 "@redocly/ajv@^8.11.2":
   version "8.17.3"
   resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.3.tgz"
@@ -1663,6 +1627,16 @@
     fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
+
+"@redocly/ajv@8.11.2":
+  version "8.11.2"
+  resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz"
+  integrity sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js-replace "^1.0.1"
 
 "@redocly/cli@^1.25.14":
   version "1.34.6"
@@ -1701,7 +1675,7 @@
   resolved "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz"
   integrity sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==
 
-"@redocly/openapi-core@1.34.6", "@redocly/openapi-core@^1.4.0":
+"@redocly/openapi-core@^1.4.0", "@redocly/openapi-core@1.34.6":
   version "1.34.6"
   resolved "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.6.tgz"
   integrity sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==
@@ -1775,13 +1749,6 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz"
-  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
-
 "@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
   version "10.3.0"
   resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz"
@@ -1802,6 +1769,13 @@
   integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
+
+"@sinonjs/fake-timers@11.2.2":
+  version "11.2.2"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz"
+  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
 
 "@sinonjs/samsam@^8.0.0":
   version "8.0.3"
@@ -2228,10 +2202,13 @@
   dependencies:
     tslib "^2.6.2"
 
-"@tokenizer/token@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz"
-  integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
+"@tokenizer/inflate@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz"
+  integrity sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==
+  dependencies:
+    debug "^4.4.3"
+    token-types "^6.1.1"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -2257,13 +2234,6 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
-
-"@tybys/wasm-util@^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -2376,13 +2346,6 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@>=13.7.0":
-  version "25.2.3"
-  resolved "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz"
-  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
-  dependencies:
-    undici-types "~7.16.0"
-
 "@types/node@^20.3.1":
   version "20.19.33"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz"
@@ -2396,6 +2359,13 @@
   integrity sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/node@>=13.7.0":
+  version "25.2.3"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz"
+  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/semver@^7.5.0":
   version "7.7.1"
@@ -2465,7 +2435,7 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/parser@^6.21.0":
+"@typescript-eslint/parser@^6.0.0 || ^6.0.0-alpha", "@typescript-eslint/parser@^6.21.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz"
   integrity sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==
@@ -2539,102 +2509,10 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@unrs/resolver-binding-android-arm-eabi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
-  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
-
-"@unrs/resolver-binding-android-arm64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
-  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
-
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
-
-"@unrs/resolver-binding-darwin-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
-  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
-
-"@unrs/resolver-binding-freebsd-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
-  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
-
-"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
-  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
-
-"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
-  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
-
-"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
-  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
-
-"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
-  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
-
-"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
-  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
-
-"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
-  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
-
-"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
-  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
-
-"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
-  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
-
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
-
-"@unrs/resolver-binding-wasm32-wasi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
-  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
-  dependencies:
-    "@napi-rs/wasm-runtime" "^0.2.11"
-
-"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
-  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
-
-"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
-  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
-
-"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
-  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 "@well-known-components/env-config-provider@^1.2.0":
   version "1.2.0"
@@ -2665,7 +2543,7 @@
     on-finished "^2.4.1"
     path-to-regexp "^6.2.1"
 
-"@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.4.2", "@well-known-components/interfaces@^1.4.3", "@well-known-components/interfaces@^1.5.2":
+"@well-known-components/interfaces@^1.0.0", "@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.4.2", "@well-known-components/interfaces@^1.4.3", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz"
   integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
@@ -2747,10 +2625,15 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 agent-base@6:
   version "6.0.2"
@@ -2758,11 +2641,6 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
-
-agent-base@^7.1.2:
-  version "7.1.4"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
-  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv-errors@^3.0.0:
   version "3.0.0"
@@ -2793,7 +2671,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.11.0, ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.11.0, ajv@^8.17.1, ajv@^8.8.2, "ajv@4.11.8 - 8":
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -2907,7 +2785,7 @@ aws-sdk@^2.1426.0, aws-sdk@^2.1545.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
-babel-jest@^29.7.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -2940,6 +2818,17 @@ babel-plugin-jest-hoist@^29.6.3:
     "@babel/types" "^7.3.3"
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
+
+"babel-plugin-module-resolver@^3.0.0 || ^4.0.0 || ^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.3.tgz"
+  integrity sha512-h8h6H71ZvdLJZxZrYkaeR30BojTaV7O9GfqacY14SNj5CNB8ocL9tydNzTC0JrnNN7vY3eJhwCmkDj7tuEUaqQ==
+  dependencies:
+    find-babel-config "^2.1.1"
+    glob "^9.3.3"
+    pkg-up "^3.1.0"
+    reselect "^4.1.7"
+    resolve "^1.22.8"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.2.0"
@@ -3053,7 +2942,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -3332,7 +3221,7 @@ cookie@^0.7.2:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-core-js@^3.32.1:
+core-js@^3.1.4, core-js@^3.32.1:
   version "3.48.0"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz"
   integrity sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==
@@ -3412,19 +3301,19 @@ dcl-catalyst-client@^21.8.0:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"
 
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 decko@^1.2.0:
   version "1.2.0"
@@ -3539,15 +3428,15 @@ dompurify@^3.2.4:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dotenv@16.4.7:
-  version "16.4.7"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
-  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
-
 dotenv@^16.0.1:
   version "16.6.1"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
+dotenv@16.4.7:
+  version "16.4.7"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -3632,7 +3521,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-prettier@^9.1.0:
+eslint-config-prettier@^9.1.0, "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
   version "9.1.2"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz"
   integrity sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==
@@ -3690,7 +3579,7 @@ eslint-plugin-css-import-order@^1.1.0:
   resolved "https://registry.npmjs.org/eslint-plugin-css-import-order/-/eslint-plugin-css-import-order-1.1.0.tgz"
   integrity sha512-43ODxP1sXpmgI4c+NCtXqmhkLsYGe8El1ewOlvsXKchLjWLxJw5zfp4eEg31Eni+is3jGkBL2TrNyUOOnbOMDg==
 
-"eslint-plugin-import@npm:eslint-plugin-i@^2.29.1":
+eslint-plugin-import@*, "eslint-plugin-import@npm:eslint-plugin-i@^2.29.1":
   version "2.29.1"
   resolved "https://registry.npmjs.org/eslint-plugin-i/-/eslint-plugin-i-2.29.1.tgz"
   integrity sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==
@@ -3730,7 +3619,7 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.57.0:
+eslint@*, "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", "eslint@^7.2.0 || ^8", eslint@^8.57.0, "eslint@>= 5.12.1", "eslint@>= 6.0.0 < 9.0.0", eslint@>=7.0.0, eslint@>=8.0.0:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -3899,7 +3788,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3919,19 +3808,19 @@ fast-uri@^3.0.1:
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-parser@5.3.4:
-  version "5.3.4"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz"
-  integrity sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==
-  dependencies:
-    strnum "^2.1.0"
-
 fast-xml-parser@^4.5.0:
   version "4.5.3"
   resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz"
   integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
   dependencies:
     strnum "^1.1.1"
+
+fast-xml-parser@5.3.4:
+  version "5.3.4"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz"
+  integrity sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==
+  dependencies:
+    strnum "^2.1.0"
 
 fastq@^1.6.0:
   version "1.20.1"
@@ -3959,15 +3848,15 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-type@15:
-  version "15.0.1"
-  resolved "https://registry.npmjs.org/file-type/-/file-type-15.0.1.tgz"
-  integrity sha512-0LieQlSA3bWUdErNrxzxfI4rhsvNAVPBO06R8pTc1hp9SE6nhqlVyvhcaXoMmtXkBTPnQenbMPLW9X76hH76oQ==
+file-type@^21.1.1:
+  version "21.3.4"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz"
+  integrity sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==
   dependencies:
-    readable-web-to-node-stream "^2.0.0"
-    strtok3 "^6.0.3"
-    token-types "^2.0.0"
-    typedarray-to-buffer "^3.1.5"
+    "@tokenizer/inflate" "^0.4.1"
+    strtok3 "^10.3.4"
+    token-types "^6.1.1"
+    uint8array-extras "^1.4.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -3975,6 +3864,13 @@ fill-range@^7.1.1:
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-babel-config@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz"
+  integrity sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==
+  dependencies:
+    json5 "^2.2.3"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -4033,7 +3929,7 @@ foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@4.0.5, form-data@^4.0.0, form-data@^4.0.4:
+form-data@^4.0.0, form-data@^4.0.4, form-data@4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -4172,6 +4068,16 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^9.3.3:
+  version "9.3.5"
+  resolved "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 glob@~11.0.0:
   version "11.0.3"
@@ -4314,15 +4220,15 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
 ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -4363,7 +4269,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.4:
+inherits@^2.0.3, inherits@~2.0.4, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4483,11 +4389,6 @@ is-typed-array@^1.1.3:
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
   dependencies:
     which-typed-array "^1.1.16"
-
-is-typedarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
 is-wsl@^3.1.0:
   version "3.1.0"
@@ -4770,7 +4671,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@^29.7.0:
+jest-resolve@*, jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -4866,7 +4767,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.7.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -4914,7 +4815,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.5.0:
+"jest@^29.0.0 || ^30.0.0", jest@^29.5.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -4944,13 +4845,6 @@ js-levenshtein@^1.1.6:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
 js-yaml@^3.13.1:
   version "3.14.2"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
@@ -4966,7 +4860,14 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsep@^1.4.0:
+js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -4986,7 +4887,7 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json-pointer@0.6.2, json-pointer@^0.6.2:
+json-pointer@^0.6.2, json-pointer@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz"
   integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
@@ -5229,13 +5130,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^10.0.3:
   version "10.2.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz"
@@ -5257,6 +5151,20 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^8.0.2:
+  version "8.0.7"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
@@ -5268,6 +5176,16 @@ minipass@^3.0.0:
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
   dependencies:
     yallist "^4.0.0"
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minipass@^5.0.0:
   version "5.0.0"
@@ -5311,7 +5229,7 @@ mobx-react@^9.1.1:
   dependencies:
     mobx-react-lite "^4.1.1"
 
-mobx@^6.0.4:
+mobx@^6.0.4, mobx@^6.9.0:
   version "6.15.0"
   resolved "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz"
   integrity sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==
@@ -5389,7 +5307,7 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@2.x, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0, node-fetch@2.x:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5579,7 +5497,14 @@ p-finally@^1.0.0:
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
   integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -5686,6 +5611,14 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.6.1:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-scurry@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz"
@@ -5708,11 +5641,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-peek-readable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz"
-  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
 perfect-scrollbar@^1.5.5:
   version "1.5.6"
@@ -5767,7 +5695,7 @@ pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@8.17.2:
+pg@^8, "pg@>=4.3.0 <9.0.0", pg@>=8.0, pg@8.17.2:
   version "8.17.2"
   resolved "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz"
   integrity sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==
@@ -5797,7 +5725,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.3:
+"picomatch@^3 || ^4", picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -5886,7 +5814,7 @@ prettier-linter-helpers@^1.0.1:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.3.2:
+prettier@^3.3.2, prettier@>=3.0.0:
   version "3.8.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz"
   integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
@@ -5953,15 +5881,15 @@ pstree.remy@^1.1.8:
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
-
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
 
 pure-rand@^6.0.0:
   version "6.1.0"
@@ -5990,7 +5918,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-"react-dom@^17.0.0 || ^18.2.0 || ^19.2.1":
+"react-dom@^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.0 || ^18.2.0 || ^19.2.1", "react-dom@>= 16.8.0":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
@@ -6015,7 +5943,7 @@ react-tabs@^6.0.2:
     clsx "^2.0.0"
     prop-types "^15.5.0"
 
-"react@^17.0.0 || ^18.2.0 || ^19.2.1":
+"react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^17.0.0 || ^18.2.0 || ^19.2.1", "react@^18.0.0 || ^19.0.0", react@^19.2.4, "react@>= 16.8.0":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react/-/react-19.2.4.tgz"
   integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
@@ -6028,11 +5956,6 @@ readable-stream@^3.0.2, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-readable-web-to-node-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz"
-  integrity sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -6099,6 +6022,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+reselect@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz"
@@ -6126,7 +6054,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.20.0, resolve@^1.22.4:
+resolve@^1.20.0, resolve@^1.22.4, resolve@^1.22.8:
   version "1.22.11"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz"
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
@@ -6173,22 +6101,32 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
-  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
-
 sax@>=0.6.0:
   version "1.4.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz"
   integrity sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
 
 scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
-semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
+semver@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -6413,6 +6351,13 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -6434,13 +6379,6 @@ string-similarity@^4.0.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -6474,15 +6412,14 @@ strnum@^2.1.0:
   resolved "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz"
   integrity sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==
 
-strtok3@^6.0.3:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz"
-  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+strtok3@^10.3.4:
+  version "10.3.5"
+  resolved "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz"
+  integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
-    peek-readable "^4.1.0"
 
-styled-components@^6.0.7:
+"styled-components@^4.1.1 || ^5.1.1 || ^6.0.5", styled-components@^6.0.7:
   version "6.3.9"
   resolved "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz"
   integrity sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==
@@ -6610,12 +6547,13 @@ toidentifier@~1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-token-types@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz"
-  integrity sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==
+token-types@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz"
+  integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
   dependencies:
-    "@tokenizer/token" "^0.1.1"
+    "@borewit/text-codec" "^0.2.1"
+    "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
 touch@^3.1.0:
@@ -6648,7 +6586,7 @@ ts-jest@^29.1.0:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2:
+ts-node@^10.9.2, ts-node@>=9.0.0:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -6667,7 +6605,7 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@2.8.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
+tslib@^2.1.0, tslib@^2.6.2, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -6684,15 +6622,15 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@4.0.8:
-  version "4.0.8"
-  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
-  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
 type-detect@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
   integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -6714,19 +6652,12 @@ typed-url-params@^1.0.1:
   resolved "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.1.tgz"
   integrity sha512-762imXO+myoSDHD9+YxUfSmfT0yGH1j+3s9UJ6uqKkOYIwHH6/gsFo67ZoST0Ey/RSoaps1zGu1N+eiuuCxfeg==
 
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
-
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.3.3:
+typescript@^5.3.3, typescript@>=2.7, typescript@>=4.2.0, "typescript@>=4.3 <6":
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -6735,6 +6666,11 @@ uglify-js@^3.1.4:
   version "3.19.3"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
+uint8array-extras@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz"
+  integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 undefsafe@^2.0.5:
   version "2.0.5"
@@ -7005,19 +6941,6 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@17.0.1:
-  version "17.0.1"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz"
-  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
-
 yargs@^17.0.1, yargs@^17.3.1, yargs@~17.7.0:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
@@ -7030,6 +6953,19 @@ yargs@^17.0.1, yargs@^17.3.1, yargs@~17.7.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yargs@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz"
+  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary

- Upgrades `@dcl/catalyst-storage` to 4.5.1 which exposes range-based `retrieve()` for partial reads from S3 and filesystem backends
- Adds RFC 7233 range request handling to the `/contents/:hashId` and `/ipfs/:hashId` GET endpoints
- Supports `bytes=START-END`, `bytes=START-`, and `bytes=-SUFFIX` range forms
- Returns `206 Partial Content` with `Content-Range` for valid ranges, `416 Range Not Satisfiable` for invalid ones
- Falls back to a full `200` response when content is compressed or file size is unknown
- Only advertises `Accept-Ranges: bytes` for uncompressed content
- Exposes `Content-Range` and `Accept-Ranges` via `Access-Control-Expose-Headers` for CORS clients

## Why

Clients fetching large content files (3D assets, textures, audio) currently must download the entire file even if they only need a portion — for example when resuming an interrupted download or streaming media. Range requests let clients request specific byte ranges, reducing bandwidth and enabling partial/resumable downloads.

## Test plan

- [ ] Unit tests for `parseRangeHeader` covering standard, open-ended, suffix, out-of-bounds, multi-range, and edge cases (12 tests, passing locally)
- [ ] Integration tests for the full request/response cycle: 206 with correct headers, suffix ranges, 416 for invalid ranges, 404 for missing files, 200 fallback without Range header (requires PostgreSQL via `docker compose up -d postgres`)
- [ ] Verify existing `/contents/:cid` and HEAD tests still pass