### PR TITLE
fix: return 400 instead of 500 for missing auth chain

### DIFF
--- a/src/logic/extract-auth-chain.ts
+++ b/src/logic/extract-auth-chain.ts
@@ -1,6 +1,7 @@
 import { FormDataContext } from './multipart'
 import { AuthChain } from '@dcl/schemas'
 import { requireString } from '../controllers/handlers/deploy-entity-handler'
+import { InvalidRequestError } from '@dcl/http-commons'
 
 export function extractAuthChain(ctx: FormDataContext): AuthChain {
   const ret: AuthChain = []
@@ -15,7 +16,7 @@ export function extractAuthChain(ctx: FormDataContext): AuthChain {
     }
   }
 
-  if (biggestIndex === -1) throw new Error('Missing auth chain')
+  if (biggestIndex === -1) throw new InvalidRequestError('Missing auth chain')
   // fill all the authChain
   for (let i = 0; i <= biggestIndex; i++) {
     ret.push({


### PR DESCRIPTION
## Summary
- Throw `InvalidRequestError` instead of plain `Error` in `extractAuthChain` so the global error handler returns a proper **400 Bad Request** with a descriptive message instead of a generic **500 Internal Server Error**

Closes decentraland/core-team#143

## Test plan
- [x] Existing tests pass
- [ ] Deploy and verify that a request with missing auth chain fields returns `400 { error: 'Bad request', message: 'Missing auth chain' }`