### PR TITLE
fix: invert show_in_places derivation from scene placesConfig.optOut

### DIFF
--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -217,7 +217,7 @@ export async function createWorldsManagerComponent({
     const categories: string[] | null = sceneMetadata.tags?.length > 0 ? sceneMetadata.tags : null
     const rating = sceneMetadata?.rating ?? null
     const singlePlayer = sceneMetadata.worldConfiguration?.fixedAdapter === 'offline:offline'
-    const showInPlaces = !!sceneMetadata.worldConfiguration?.placesConfig?.optOut
+    const showInPlaces = !sceneMetadata.worldConfiguration?.placesConfig?.optOut
 
     // Extract thumbnail hash from scene content
     const navmapThumbnail = sceneMetadata.display?.navmapThumbnail

--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -30,7 +30,7 @@ import {
 import { streamToBuffer } from '@dcl/catalyst-storage'
 import { Entity, EthAddress } from '@dcl/schemas'
 import SQL from 'sql-template-strings'
-import { buildWorldRuntimeMetadata } from '../logic/world-runtime-metadata-utils'
+import { buildWorldRuntimeMetadata, shouldShowInPlaces } from '../logic/world-runtime-metadata-utils'
 import { AccessSetting, defaultAccess } from '../logic/access'
 
 type BoundingRow = { min_x: number; max_x: number; min_y: number; max_y: number }
@@ -217,7 +217,7 @@ export async function createWorldsManagerComponent({
     const categories: string[] | null = sceneMetadata.tags?.length > 0 ? sceneMetadata.tags : null
     const rating = sceneMetadata?.rating ?? null
     const singlePlayer = sceneMetadata.worldConfiguration?.fixedAdapter === 'offline:offline'
-    const showInPlaces = !sceneMetadata.worldConfiguration?.placesConfig?.optOut
+    const showInPlaces = shouldShowInPlaces(sceneMetadata)
 
     // Extract thumbnail hash from scene content
     const navmapThumbnail = sceneMetadata.display?.navmapThumbnail

--- a/src/logic/world-runtime-metadata-utils.ts
+++ b/src/logic/world-runtime-metadata-utils.ts
@@ -61,7 +61,15 @@ export function extractWorldRuntimeMetadata(worldName: string, entity: Entity): 
   }
 }
 
-export function shouldShowInPlaces(sceneMetadata: any): boolean {
+export type SceneMetadataForShowInPlaces = {
+  worldConfiguration?: {
+    placesConfig?: {
+      optOut?: boolean
+    }
+  }
+}
+
+export function shouldShowInPlaces(sceneMetadata: SceneMetadataForShowInPlaces | null | undefined): boolean {
   return !sceneMetadata?.worldConfiguration?.placesConfig?.optOut
 }
 

--- a/src/logic/world-runtime-metadata-utils.ts
+++ b/src/logic/world-runtime-metadata-utils.ts
@@ -61,6 +61,10 @@ export function extractWorldRuntimeMetadata(worldName: string, entity: Entity): 
   }
 }
 
+export function shouldShowInPlaces(sceneMetadata: any): boolean {
+  return !sceneMetadata?.worldConfiguration?.placesConfig?.optOut
+}
+
 export function buildWorldRuntimeMetadata(worldName: string, scenes: any[]): WorldRuntimeMetadata {
   // Derive runtime metadata from scenes
   if (scenes.length > 0) {

--- a/test/integration/deploy.spec.ts
+++ b/test/integration/deploy.spec.ts
@@ -896,6 +896,9 @@ test('DeployEntity POST /entities', function ({ components, stubComponents }) {
               name: worldName,
               skyboxConfig: {
                 fixedTime: 1200
+              },
+              placesConfig: {
+                optOut: true
               }
             }
           }
@@ -950,7 +953,8 @@ test('DeployEntity POST /entities', function ({ components, stubComponents }) {
           description: 'Original description',
           spawnCoordinates: '0,0',
           skyboxTime: 1200,
-          categories: ['original']
+          categories: ['original'],
+          showInPlaces: false
         })
       })
     })

--- a/test/integration/deploy.spec.ts
+++ b/test/integration/deploy.spec.ts
@@ -787,7 +787,7 @@ test('DeployEntity POST /entities', function ({ components, stubComponents }) {
           skyboxTime: 3600,
           categories: ['adventure', 'exploration', 'fantasy'],
           singlePlayer: true,
-          showInPlaces: true,
+          showInPlaces: false,
           thumbnailHash: thumbnailHash
         })
       })
@@ -810,7 +810,7 @@ test('DeployEntity POST /entities', function ({ components, stubComponents }) {
           skybox_time: 3600,
           categories: ['adventure', 'exploration', 'fantasy'],
           single_player: true,
-          show_in_places: true,
+          show_in_places: false,
           thumbnail_hash: thumbnailHash
         })
       })
@@ -860,7 +860,7 @@ test('DeployEntity POST /entities', function ({ components, stubComponents }) {
         expect(settings?.skyboxTime).toBeUndefined()
         expect(settings?.categories).toBeUndefined()
         expect(settings?.singlePlayer).toBe(false)
-        expect(settings?.showInPlaces).toBe(false)
+        expect(settings?.showInPlaces).toBe(true)
         expect(settings?.thumbnailHash).toBeUndefined()
       })
     })

--- a/test/integration/worlds-handler.spec.ts
+++ b/test/integration/worlds-handler.spec.ts
@@ -98,7 +98,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         shape: { x1: 0, x2: 1, y1: 0, y2: 0 },
         spawn_coordinates: '0,0',
         single_player: false,
-        show_in_places: false,
+        show_in_places: true,
         last_deployed_at: expect.any(String),
         blocked_since: null,
         deployed_scenes: 1
@@ -113,7 +113,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         shape: { x1: 5, x2: 6, y1: 5, y2: 6 },
         spawn_coordinates: '5,5',
         single_player: false,
-        show_in_places: false,
+        show_in_places: true,
         last_deployed_at: expect.any(String),
         blocked_since: null,
         deployed_scenes: 1
@@ -128,7 +128,7 @@ test('WorldsHandler GET /worlds', function ({ components }) {
         shape: { x1: 10, x2: 10, y1: 10, y2: 10 },
         spawn_coordinates: '10,10',
         single_player: false,
-        show_in_places: false,
+        show_in_places: true,
         last_deployed_at: expect.any(String),
         blocked_since: null,
         deployed_scenes: 1

--- a/test/unit/world-runtime-metadata-utils.spec.ts
+++ b/test/unit/world-runtime-metadata-utils.spec.ts
@@ -1,7 +1,8 @@
 import {
   extractWorldRuntimeMetadata,
   migrateConfiguration,
-  buildWorldRuntimeMetadata
+  buildWorldRuntimeMetadata,
+  shouldShowInPlaces
 } from '../../src/logic/world-runtime-metadata-utils'
 import { EntityType, WorldConfiguration } from '@dcl/schemas'
 
@@ -290,6 +291,56 @@ describe('world-runtime-metadata-utils', function () {
 
         expect(result.entityIds).toEqual(['first-scene'])
         expect(result.name).toBe('first-scene-name')
+      })
+    })
+  })
+
+  describe('shouldShowInPlaces', function () {
+    describe('when the scene metadata is null or undefined', function () {
+      it('should return true for undefined metadata', function () {
+        expect(shouldShowInPlaces(undefined)).toBe(true)
+      })
+
+      it('should return true for null metadata', function () {
+        expect(shouldShowInPlaces(null)).toBe(true)
+      })
+
+      it('should return true for empty metadata', function () {
+        expect(shouldShowInPlaces({})).toBe(true)
+      })
+    })
+
+    describe('when the scene has no worldConfiguration', function () {
+      it('should return true', function () {
+        expect(shouldShowInPlaces({ display: { title: 'A World' } })).toBe(true)
+      })
+    })
+
+    describe('when the scene has a worldConfiguration but no placesConfig', function () {
+      it('should return true', function () {
+        expect(shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth' } })).toBe(true)
+      })
+    })
+
+    describe('when the scene has a placesConfig but no optOut flag', function () {
+      it('should return true', function () {
+        expect(shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: {} } })).toBe(true)
+      })
+    })
+
+    describe('when the scene explicitly opts in (optOut=false)', function () {
+      it('should return true', function () {
+        expect(
+          shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: { optOut: false } } })
+        ).toBe(true)
+      })
+    })
+
+    describe('when the scene explicitly opts out (optOut=true)', function () {
+      it('should return false', function () {
+        expect(
+          shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: { optOut: true } } })
+        ).toBe(false)
       })
     })
   })

--- a/test/unit/world-runtime-metadata-utils.spec.ts
+++ b/test/unit/world-runtime-metadata-utils.spec.ts
@@ -312,35 +312,31 @@ describe('world-runtime-metadata-utils', function () {
 
     describe('when the scene has no worldConfiguration', function () {
       it('should return true', function () {
-        expect(shouldShowInPlaces({ display: { title: 'A World' } })).toBe(true)
+        expect(shouldShowInPlaces({})).toBe(true)
       })
     })
 
     describe('when the scene has a worldConfiguration but no placesConfig', function () {
       it('should return true', function () {
-        expect(shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth' } })).toBe(true)
+        expect(shouldShowInPlaces({ worldConfiguration: {} })).toBe(true)
       })
     })
 
     describe('when the scene has a placesConfig but no optOut flag', function () {
       it('should return true', function () {
-        expect(shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: {} } })).toBe(true)
+        expect(shouldShowInPlaces({ worldConfiguration: { placesConfig: {} } })).toBe(true)
       })
     })
 
     describe('when the scene explicitly opts in (optOut=false)', function () {
       it('should return true', function () {
-        expect(
-          shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: { optOut: false } } })
-        ).toBe(true)
+        expect(shouldShowInPlaces({ worldConfiguration: { placesConfig: { optOut: false } } })).toBe(true)
       })
     })
 
     describe('when the scene explicitly opts out (optOut=true)', function () {
       it('should return false', function () {
-        expect(
-          shouldShowInPlaces({ worldConfiguration: { name: 'some.dcl.eth', placesConfig: { optOut: true } } })
-        ).toBe(false)
+        expect(shouldShowInPlaces({ worldConfiguration: { placesConfig: { optOut: true } } })).toBe(false)
       })
     })
   })


### PR DESCRIPTION
## Why

On first scene deployment, the `worlds` row was written with `show_in_places` set to the literal value of `placesConfig.optOut`, which has the opposite semantics of the column. A scene without `placesConfig` (the common default, meaning the owner has *not* opted out of places) was being stored with `show_in_places = false`, and a scene that explicitly opted out was being stored with `show_in_places = true`.

This value is then returned by `GET /world/:name/settings` and propagated to downstream consumers via `WorldSettingsChangedEvent` whenever settings change. The places service reconciles its `worlds` table from those events, so the inverted flag ends up hiding legitimately-public worlds (or surfacing opted-out ones) as soon as the owner touches any other setting. The bug was confirmed live on `flagtag.dcl.eth`: the scene has no `placesConfig`, yet both the content server's settings endpoint and the places row it eventually synced to were returning `show_in_places: false`.

The scene-metadata → world-row mapping already gets this right in the places repo (`show_in_places: !isOptOut`), so this change brings the content server in line with that contract.

## How

- `src/adapters/worlds-manager.ts`: changed `!!sceneMetadata.worldConfiguration?.placesConfig?.optOut` to `!sceneMetadata.worldConfiguration?.placesConfig?.optOut` in the INSERT path of the first-deployment upsert. The ON CONFLICT branch is unchanged — existing rows are not touched by a redeployment, which is the intended behavior (user-controlled settings live on through redeploys).
- `test/integration/deploy.spec.ts`: flipped three assertions that had encoded the inverted semantics:
  - Full-metadata scene with `placesConfig.optOut: true` → now expects `showInPlaces: false` / `show_in_places: false`.
  - Minimal-metadata scene with no `placesConfig` → now expects `showInPlaces: true`.

No schema or migration change: the column type and default are already correct, only the value being written was wrong.

## Follow-ups (not in this PR)

Existing rows written before this fix still hold the inverted value and will continue to propagate it to places on the next settings event. A backfill is needed to flip them, but distinguishing "inverted by this bug" from "deliberately set via the settings API" cleanly is non-trivial and worth its own discussion before shipping.

## Test plan

- [ ] `npm test` passes (unit + integration).
- [ ] Deploy a new world with no `placesConfig` and confirm `GET /world/:name/settings` returns `show_in_places: true`.
- [ ] Deploy a new world with `placesConfig.optOut: true` and confirm `GET /world/:name/settings` returns `show_in_places: false`.
- [ ] Redeploy an existing world and confirm its stored `show_in_places` is preserved (ON CONFLICT path unchanged).