### PR TITLE
feat: use asset-bundle-registry denylist to filter active scene entities

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -65,6 +65,7 @@ NATS_URL=nats://localhost:4222
 ##  Ban Checking & Denylist         ##
 ######################################
 DENYLIST_JSON_URL=https://config.decentraland.org/denylist.json
+ASSET_BUNDLE_REGISTRY_URL=https://asset-bundle-registry.decentraland.org
 COMMS_GATEKEEPER_URL=https://comms-gatekeeper.decentraland.org
 COMMS_GATEKEEPER_AUTH_TOKEN=<PLACEHOLDER>
 

--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -39,12 +39,13 @@ export async function createWorldsManagerComponent({
   coordinates,
   logs,
   database,
+  denyList,
   nameDenyListChecker,
   search,
   storage
 }: Pick<
   AppComponents,
-  'coordinates' | 'logs' | 'database' | 'nameDenyListChecker' | 'search' | 'storage'
+  'coordinates' | 'logs' | 'database' | 'denyList' | 'nameDenyListChecker' | 'search' | 'storage'
 >): Promise<IWorldsManager> {
   const logger = logs.getLogger('worlds-manager')
   const { extractSpawnCoordinates, parseCoordinate, isCoordinateWithinRectangle, getRectangleCenter } = coordinates
@@ -373,14 +374,21 @@ export async function createWorldsManagerComponent({
       `
     )
 
-    return result.rows.map((row) => ({
-      ...row.entity,
-      id: row.entity_id,
-      metadata: {
-        ...row.entity.metadata,
-        owner: row.owner
-      }
-    }))
+    const entities = await Promise.all(
+      result.rows.map(async (row) => {
+        if (await denyList.isEntityDenylisted(row.entity_id)) return null
+        return {
+          ...row.entity,
+          id: row.entity_id,
+          metadata: {
+            ...row.entity.metadata,
+            owner: row.owner
+          }
+        }
+      })
+    )
+
+    return entities.filter((e): e is Entity => e !== null)
   }
 
   async function undeployWorld(worldName: string): Promise<void> {

--- a/src/components.ts
+++ b/src/components.ts
@@ -140,10 +140,13 @@ export async function initComponents(): Promise<AppComponents> {
 
   const search = await createSearchComponent({ database, logs })
 
+  const denyList = await createDenyListComponent({ config, fetch, logs })
+
   const worldsManager = await createWorldsManagerComponent({
     coordinates,
     logs,
     database,
+    denyList,
     nameDenyListChecker,
     search,
     storage
@@ -222,7 +225,6 @@ export async function initComponents(): Promise<AppComponents> {
 
   const evictionJob = await createEvictionJob({ config, logs, worlds })
 
-  const denyList = await createDenyListComponent({ config, fetch, logs })
   const bans = await createBansComponent({ config, fetch, logs })
 
   const comms = await createCommsComponent({

--- a/src/logic/comms/component.ts
+++ b/src/logic/comms/component.ts
@@ -29,7 +29,7 @@ export const createCommsComponent = async (
   }
 
   async function assertUserNotDenylisted(userAddress: EthAddress): Promise<void> {
-    const isDenylisted = await denyList.isDenylisted(userAddress)
+    const isDenylisted = await denyList.isWalletDenylisted(userAddress)
     if (isDenylisted) {
       throw new UserDenylistedError()
     }

--- a/src/logic/denylist/component.ts
+++ b/src/logic/denylist/component.ts
@@ -2,17 +2,9 @@ import { LRUCache } from 'lru-cache'
 import { AppComponents } from '../../types'
 import { IDenyListComponent } from './types'
 
-const DENYLIST_CACHE_KEY = 'DENYLIST'
+const WALLET_DENYLIST_CACHE_KEY = 'WALLET_DENYLIST'
+const ENTITY_DENYLIST_CACHE_KEY = 'ENTITY_DENYLIST'
 
-/**
- * Creates the DenyList component.
- *
- * Fetches and caches the global denylist of wallet addresses from an external URL.
- * Uses LRU cache with a 5-minute TTL to avoid fetching on every request.
- *
- * @param components Required components: config, fetch, logs
- * @returns IDenyListComponent implementation
- */
 export async function createDenyListComponent(
   components: Pick<AppComponents, 'config' | 'fetch' | 'logs'>
 ): Promise<IDenyListComponent> {
@@ -20,10 +12,11 @@ export async function createDenyListComponent(
   const logger = logs.getLogger('denylist-component')
 
   const denylistUrl = await config.requireString('DENYLIST_JSON_URL')
+  const assetBundleRegistryUrl = await config.requireString('ASSET_BUNDLE_REGISTRY_URL')
 
-  const denylistCache = new LRUCache<string, Set<string>>({
+  const walletDenylistCache = new LRUCache<string, Set<string>>({
     max: 1,
-    ttl: 5 * 60 * 1000, // cache for 5 minutes
+    ttl: 5 * 60 * 1000,
     fetchMethod: async (): Promise<Set<string>> => {
       try {
         const response = await fetch.fetch(denylistUrl)
@@ -35,24 +28,44 @@ export async function createDenyListComponent(
 
         throw Error('Did not get an array of users')
       } catch (error) {
-        logger.warn(`Failed to fetch denylist from ${denylistUrl}: ${error}`)
+        logger.warn(`Failed to fetch wallet denylist from ${denylistUrl}: ${error}`)
         return new Set()
       }
     }
   })
 
-  /**
-   * Checks if the given identity (wallet address) is in the global denylist.
-   *
-   * @param identity - The wallet address to check.
-   * @returns True if the identity is denylisted, false otherwise.
-   */
-  async function isDenylisted(identity: string): Promise<boolean> {
-    const denyList = await denylistCache.fetch(DENYLIST_CACHE_KEY)
+  const entityDenylistCache = new LRUCache<string, Set<string>>({
+    max: 1,
+    ttl: 5 * 60 * 1000,
+    fetchMethod: async (): Promise<Set<string>> => {
+      try {
+        const response = await fetch.fetch(`${assetBundleRegistryUrl}/denylist`)
+        const data: { entity_id: string }[] = await response.json()
+
+        if (Array.isArray(data)) {
+          return new Set(data.map((entry) => entry.entity_id.toLowerCase()))
+        }
+
+        throw Error('Did not get an array of denylist entries')
+      } catch (error) {
+        logger.warn(`Failed to fetch entity denylist from ${assetBundleRegistryUrl}/denylist: ${error}`)
+        return new Set()
+      }
+    }
+  })
+
+  async function isWalletDenylisted(identity: string): Promise<boolean> {
+    const denyList = await walletDenylistCache.fetch(WALLET_DENYLIST_CACHE_KEY)
     return denyList?.has(identity.toLowerCase()) ?? false
   }
 
+  async function isEntityDenylisted(entityId: string): Promise<boolean> {
+    const denyList = await entityDenylistCache.fetch(ENTITY_DENYLIST_CACHE_KEY)
+    return denyList?.has(entityId.toLowerCase()) ?? false
+  }
+
   return {
-    isDenylisted
+    isWalletDenylisted,
+    isEntityDenylisted
   }
 }

--- a/src/logic/denylist/types.ts
+++ b/src/logic/denylist/types.ts
@@ -1,12 +1,4 @@
-/**
- * Component interface for checking if a wallet address is in the global denylist.
- */
 export type IDenyListComponent = {
-  /**
-   * Checks if the given identity (wallet address) is in the global denylist.
-   *
-   * @param identity - The wallet address to check.
-   * @returns True if the identity is denylisted, false otherwise.
-   */
-  isDenylisted: (identity: string) => Promise<boolean>
+  isWalletDenylisted: (identity: string) => Promise<boolean>
+  isEntityDenylisted: (entityId: string) => Promise<boolean>
 }

--- a/test/components.ts
+++ b/test/components.ts
@@ -108,10 +108,13 @@ async function initComponents(): Promise<TestComponents> {
 
   const search = await createSearchComponent({ database, logs })
 
+  const denyList = createMockDenyList()
+
   const worldsManager = await createWorldsManagerComponent({
     coordinates,
     logs,
     database,
+    denyList,
     nameDenyListChecker,
     search,
     storage
@@ -185,7 +188,6 @@ async function initComponents(): Promise<TestComponents> {
   const redis = createRedisMock()
   const rateLimiter = await createRateLimiterComponent({ config, redis })
 
-  const denyList = createMockDenyList()
   const bans = createMockBans()
 
   const comms = await createCommsComponent({

--- a/test/integration/active-entities-handler.spec.ts
+++ b/test/integration/active-entities-handler.spec.ts
@@ -166,4 +166,22 @@ test('active entities handler /entities/active', function ({ components }) {
       id: world1.entityId
     })
   })
+
+  it('when entity is denylisted it is excluded from the response', async () => {
+    const { localFetch, worldCreator, denyList } = components
+
+    const { worldName, entityId } = await worldCreator.createWorldWithScene()
+    denyList.isEntityDenylisted.mockImplementation(async (id) => id === entityId)
+
+    const r = await localFetch.fetch('/entities/active', {
+      method: 'POST',
+      body: JSON.stringify({ pointers: [worldName] }),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    expect(r.status).toEqual(200)
+    expect(await r.json()).toEqual([])
+  })
 })

--- a/test/integration/world-comms-handler.spec.ts
+++ b/test/integration/world-comms-handler.spec.ts
@@ -142,7 +142,7 @@ test('world comms handler', function ({ components, stubComponents }) {
     describe('and the user is denylisted', () => {
       beforeEach(() => {
         const { denyList } = stubComponents as any
-        denyList.isDenylisted.resolves(true)
+        denyList.isWalletDenylisted.resolves(true)
       })
 
       it('should respond with 401 and the deny-listed error', async () => {

--- a/test/mocks/denylist-mock.ts
+++ b/test/mocks/denylist-mock.ts
@@ -4,7 +4,8 @@ export const createMockDenyList = (
   overrides?: Partial<jest.Mocked<IDenyListComponent>>
 ): jest.Mocked<IDenyListComponent> => {
   return {
-    isDenylisted: jest.fn().mockResolvedValue(false),
+    isWalletDenylisted: jest.fn().mockResolvedValue(false),
+    isEntityDenylisted: jest.fn().mockResolvedValue(false),
     ...overrides
   }
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,5 +1,6 @@
 import { AppComponents, INameOwnership, IWorldCreator } from '../src/types'
 import { IAuthenticatedFetchComponent } from './components/local-auth-fetch'
+import { IDenyListComponent } from '../src/logic/denylist/types'
 
 // components used in tests
 export type TestComponents = AppComponents & {
@@ -8,4 +9,6 @@ export type TestComponents = AppComponents & {
   worldCreator: IWorldCreator
   // Mocked version of nameOwnership for testing
   nameOwnership: jest.Mocked<INameOwnership>
+  // Mocked version of denyList for testing
+  denyList: jest.Mocked<IDenyListComponent>
 }

--- a/test/unit/comms-component.spec.ts
+++ b/test/unit/comms-component.spec.ts
@@ -436,7 +436,7 @@ describe('CommsComponent', () => {
         } catch {
           // Expected to throw
         }
-        expect(denyList.isDenylisted).not.toHaveBeenCalled()
+        expect(denyList.isWalletDenylisted).not.toHaveBeenCalled()
       })
 
       it('should not check world validity', async () => {
@@ -466,7 +466,7 @@ describe('CommsComponent', () => {
         } catch {
           // Expected to throw
         }
-        expect(denyList.isDenylisted).not.toHaveBeenCalled()
+        expect(denyList.isWalletDenylisted).not.toHaveBeenCalled()
       })
     })
   })
@@ -477,7 +477,7 @@ describe('CommsComponent', () => {
 
     describe('and getting the world room connection string', () => {
       beforeEach(() => {
-        denyList.isDenylisted.mockResolvedValueOnce(true)
+        denyList.isWalletDenylisted.mockResolvedValueOnce(true)
       })
 
       it('should throw UserDenylistedError', async () => {
@@ -508,7 +508,7 @@ describe('CommsComponent', () => {
 
     describe('and getting the scene room connection string', () => {
       beforeEach(() => {
-        denyList.isDenylisted.mockResolvedValueOnce(true)
+        denyList.isWalletDenylisted.mockResolvedValueOnce(true)
       })
 
       it('should throw UserDenylistedError', async () => {
@@ -607,7 +607,7 @@ describe('CommsComponent', () => {
     describe('and the user is denylisted', () => {
       describe('and getting the scene room connection string', () => {
         beforeEach(() => {
-          denyList.isDenylisted.mockResolvedValueOnce(true)
+          denyList.isWalletDenylisted.mockResolvedValueOnce(true)
         })
 
         it('should throw UserDenylistedError before reaching ban check', async () => {
@@ -622,7 +622,7 @@ describe('CommsComponent', () => {
     describe('and neither check restricts the user', () => {
       describe('and getting the world room connection string', () => {
         beforeEach(() => {
-          denyList.isDenylisted.mockResolvedValueOnce(false)
+          denyList.isWalletDenylisted.mockResolvedValueOnce(false)
           worlds.isWorldValid.mockResolvedValueOnce(true)
           namePermissionChecker.checkPermission.mockResolvedValueOnce(true)
           access.checkAccess.mockResolvedValueOnce(true)
@@ -637,14 +637,14 @@ describe('CommsComponent', () => {
 
         it('should call denylist checker but not scene ban checker', async () => {
           await commsComponent.getWorldRoomConnectionString(userAddress, worldName)
-          expect(denyList.isDenylisted).toHaveBeenCalledWith(userAddress)
+          expect(denyList.isWalletDenylisted).toHaveBeenCalledWith(userAddress)
           expect(bans.isUserBannedFromScene).not.toHaveBeenCalled()
         })
       })
 
       describe('and getting the scene room connection string', () => {
         beforeEach(() => {
-          denyList.isDenylisted.mockResolvedValueOnce(false)
+          denyList.isWalletDenylisted.mockResolvedValueOnce(false)
           worlds.isWorldValid.mockResolvedValueOnce(true)
           namePermissionChecker.checkPermission.mockResolvedValueOnce(true)
           access.checkAccess.mockResolvedValueOnce(true)
@@ -661,7 +661,7 @@ describe('CommsComponent', () => {
 
         it('should call both denylist and scene ban checker', async () => {
           await commsComponent.getWorldSceneRoomConnectionString(userAddress, worldName, sceneId)
-          expect(denyList.isDenylisted).toHaveBeenCalledWith(userAddress)
+          expect(denyList.isWalletDenylisted).toHaveBeenCalledWith(userAddress)
           expect(bans.isUserBannedFromScene).toHaveBeenCalledWith(userAddress, worldName, sceneBaseParcel)
         })
       })

--- a/test/unit/denylist-component.spec.ts
+++ b/test/unit/denylist-component.spec.ts
@@ -6,9 +6,10 @@ import { createMockedConfig } from '../mocks/config-mock'
 import { createMockFetch } from '../mocks/fetch-mock'
 import { createMockLogs } from '../mocks/logs-mock'
 
-describe('DenyListComponent', () => {
-  const denylistUrl = 'https://config.decentraland.org/denylist.json'
+const DENYLIST_URL = 'https://config.decentraland.org/denylist.json'
+const ASSET_BUNDLE_REGISTRY_URL = 'https://asset-bundle-registry.decentraland.org'
 
+describe('DenyListComponent', () => {
   let denyListComponent: IDenyListComponent
   let fetch: jest.Mocked<IFetchComponent>
 
@@ -26,7 +27,11 @@ describe('DenyListComponent', () => {
 
     denyListComponent = await createDenyListComponent({
       config: createMockedConfig({
-        requireString: jest.fn().mockResolvedValue(denylistUrl)
+        requireString: jest.fn().mockImplementation(async (key: string) => {
+          if (key === 'DENYLIST_JSON_URL') return DENYLIST_URL
+          if (key === 'ASSET_BUNDLE_REGISTRY_URL') return ASSET_BUNDLE_REGISTRY_URL
+          throw new Error(`Unknown config key: ${key}`)
+        })
       }),
       fetch,
       logs: createMockLogs()
@@ -37,29 +42,29 @@ describe('DenyListComponent', () => {
     jest.resetAllMocks()
   })
 
-  describe('when checking if a user is denylisted', () => {
-    describe('and the user is in the denylist', () => {
+  describe('isWalletDenylisted', () => {
+    describe('when the wallet is in the denylist', () => {
       it('should return true', async () => {
-        const result = await denyListComponent.isDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
+        const result = await denyListComponent.isWalletDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
         expect(result).toBe(true)
       })
     })
 
-    describe('and the user is not in the denylist', () => {
+    describe('when the wallet is not in the denylist', () => {
       it('should return false', async () => {
-        const result = await denyListComponent.isDenylisted('0x2222222222222222222222222222222222222222')
+        const result = await denyListComponent.isWalletDenylisted('0x2222222222222222222222222222222222222222')
         expect(result).toBe(false)
       })
     })
 
-    describe('and the denylist check is case-insensitive', () => {
+    describe('when the check is case-insensitive', () => {
       it('should match regardless of case', async () => {
-        const result = await denyListComponent.isDenylisted('0xABCDEF1234567890ABCDEF1234567890ABCDEF12')
+        const result = await denyListComponent.isWalletDenylisted('0xABCDEF1234567890ABCDEF1234567890ABCDEF12')
         expect(result).toBe(true)
       })
     })
 
-    describe('and the denylist response has no users array', () => {
+    describe('when the denylist response has no users array', () => {
       beforeEach(() => {
         fetch.fetch.mockResolvedValue({
           json: jest.fn().mockResolvedValue({ invalid: 'response' })
@@ -67,18 +72,81 @@ describe('DenyListComponent', () => {
       })
 
       it('should return false', async () => {
-        const result = await denyListComponent.isDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
+        const result = await denyListComponent.isWalletDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
         expect(result).toBe(false)
       })
     })
 
-    describe('and the fetch fails', () => {
+    describe('when the fetch fails', () => {
       beforeEach(() => {
         fetch.fetch.mockRejectedValue(new Error('Network error'))
       })
 
       it('should return false', async () => {
-        const result = await denyListComponent.isDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
+        const result = await denyListComponent.isWalletDenylisted('0xabcdef1234567890abcdef1234567890abcdef12')
+        expect(result).toBe(false)
+      })
+    })
+  })
+
+  describe('isEntityDenylisted', () => {
+    const deniedEntityId = 'bafyreic1111111111111111111111111111111111111111111111111111111'
+    const otherEntityId = 'bafyreic2222222222222222222222222222222222222222222222222222222'
+
+    beforeEach(() => {
+      fetch.fetch.mockImplementation(async (url: string) => {
+        if (String(url).includes('/denylist') && !String(url).endsWith('denylist.json')) {
+          return {
+            json: jest.fn().mockResolvedValue([{ entity_id: deniedEntityId }])
+          } as unknown as Response
+        }
+        return {
+          json: jest.fn().mockResolvedValue({ users: [] })
+        } as unknown as Response
+      })
+    })
+
+    describe('when the entity is in the denylist', () => {
+      it('should return true', async () => {
+        const result = await denyListComponent.isEntityDenylisted(deniedEntityId)
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('when the entity is not in the denylist', () => {
+      it('should return false', async () => {
+        const result = await denyListComponent.isEntityDenylisted(otherEntityId)
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('when the check is case-insensitive', () => {
+      it('should match regardless of case', async () => {
+        const result = await denyListComponent.isEntityDenylisted(deniedEntityId.toUpperCase())
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('when the denylist response is not an array', () => {
+      beforeEach(() => {
+        fetch.fetch.mockResolvedValue({
+          json: jest.fn().mockResolvedValue({ invalid: 'response' })
+        } as unknown as Response)
+      })
+
+      it('should return false', async () => {
+        const result = await denyListComponent.isEntityDenylisted(deniedEntityId)
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('when the fetch fails', () => {
+      beforeEach(() => {
+        fetch.fetch.mockRejectedValue(new Error('Network error'))
+      })
+
+      it('should return false', async () => {
+        const result = await denyListComponent.isEntityDenylisted(deniedEntityId)
         expect(result).toBe(false)
       })
     })


### PR DESCRIPTION
## Summary

- Replaces `config.decentraland.org/denylist.json` (wallet-based) with the new public `GET /denylist` endpoint from [asset-bundle-registry#114](https://github.com/decentraland/asset-bundle-registry/pull/114), which returns denylisted **entity IDs**
- Consolidates all denylist logic in `IDenyListComponent`: renames `isDenylisted` → `isWalletDenylisted` (comms access control) and adds `isEntityDenylisted` (entity filtering) with its own 5-min LRU cache
- Filters denylisted entities out of the `POST /entities/active` response inside `getEntityForWorlds`

## Test plan

- [ ] All 614 unit tests pass (`yarn jest test/unit`)
- [ ] `isWalletDenylisted` unit tests cover: hit, miss, case-insensitivity, malformed response, fetch failure
- [ ] `isEntityDenylisted` unit tests cover the same cases
- [ ] New integration test asserts a denylisted entity is excluded from `POST /entities/active`
- [ ] Set `ASSET_BUNDLE_REGISTRY_URL` in the deployment environment