### PR TITLE
feat: allow world-wide deployers to update world settings

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -212,6 +212,7 @@ export async function initComponents(): Promise<AppComponents> {
     config,
     coordinates,
     namePermissionChecker,
+    permissions,
     storage,
     snsClient,
     worldsManager

--- a/src/logic/settings/component.ts
+++ b/src/logic/settings/component.ts
@@ -15,13 +15,7 @@ import { Coordinate } from '../coordinates'
 export async function createSettingsComponent(
   components: Pick<
     AppComponents,
-    | 'config'
-    | 'coordinates'
-    | 'namePermissionChecker'
-    | 'permissions'
-    | 'storage'
-    | 'snsClient'
-    | 'worldsManager'
+    'config' | 'coordinates' | 'namePermissionChecker' | 'permissions' | 'storage' | 'snsClient' | 'worldsManager'
   >
 ): Promise<ISettingsComponent> {
   const { config, coordinates, namePermissionChecker, permissions, storage, snsClient, worldsManager } = components

--- a/src/logic/settings/component.ts
+++ b/src/logic/settings/component.ts
@@ -15,10 +15,16 @@ import { Coordinate } from '../coordinates'
 export async function createSettingsComponent(
   components: Pick<
     AppComponents,
-    'config' | 'coordinates' | 'namePermissionChecker' | 'storage' | 'snsClient' | 'worldsManager'
+    | 'config'
+    | 'coordinates'
+    | 'namePermissionChecker'
+    | 'permissions'
+    | 'storage'
+    | 'snsClient'
+    | 'worldsManager'
   >
 ): Promise<ISettingsComponent> {
-  const { config, coordinates, namePermissionChecker, storage, snsClient, worldsManager } = components
+  const { config, coordinates, namePermissionChecker, permissions, storage, snsClient, worldsManager } = components
   const baseUrl = await config.requireString('HTTP_BASE_URL')
 
   const { parseCoordinate, areCoordinatesEqual } = coordinates
@@ -47,10 +53,11 @@ export async function createSettingsComponent(
   ): Promise<WorldSettings> {
     const normalizedSigner = signer.toLowerCase()
 
-    // Only name owners can update world settings
-    const hasNamePermission = await namePermissionChecker.checkPermission(normalizedSigner, worldName)
+    const isNameOwner = await namePermissionChecker.checkPermission(normalizedSigner, worldName)
+    const isWorldWideDeployer =
+      !isNameOwner && (await permissions.hasWorldWidePermission(worldName, 'deployment', normalizedSigner))
 
-    if (!hasNamePermission) {
+    if (!isNameOwner && !isWorldWideDeployer) {
       throw new UnauthorizedError()
     }
 

--- a/test/components.ts
+++ b/test/components.ts
@@ -173,6 +173,7 @@ async function initComponents(): Promise<TestComponents> {
     config,
     coordinates,
     namePermissionChecker,
+    permissions,
     storage,
     snsClient,
     worldsManager

--- a/test/integration/world-settings-handler.spec.ts
+++ b/test/integration/world-settings-handler.spec.ts
@@ -247,7 +247,7 @@ test('WorldSettingsHandler', ({ components, stubComponents }) => {
       })
     })
 
-    describe('when the user has deployment permission but does not own the name', () => {
+    describe('when the user has world-wide deployment permission but does not own the name', () => {
       let deployer: Identity
       let worldName: string
       let permissions: IPermissionsComponent
@@ -261,10 +261,50 @@ test('WorldSettingsHandler', ({ components, stubComponents }) => {
         const created = await worldCreator.createWorldWithScene()
         worldName = created.worldName
 
-        // Grant deployment permission to the deployer
         await permissions.grantWorldWidePermission(worldName, 'deployment', [
           deployer.realAccount.address.toLowerCase()
         ])
+      })
+
+      it('should update the world settings successfully', async () => {
+        const { localFetch, worldsManager } = components
+
+        const response = await makeSignedMultipartRequest(localFetch, `/world/${worldName}/settings`, deployer, {
+          spawn_coordinates: '20,24'
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({
+          message: 'World settings updated successfully',
+          settings: {
+            spawn_coordinates: '20,24'
+          }
+        })
+
+        const settings = await worldsManager.getWorldSettings(worldName)
+        expect(settings).toMatchObject({
+          spawnCoordinates: '20,24'
+        })
+      })
+    })
+
+    describe('when the user has parcel-scoped deployment permission but does not own the name', () => {
+      let deployer: Identity
+      let worldName: string
+      let permissions: IPermissionsComponent
+
+      beforeEach(async () => {
+        const { worldCreator } = components
+        permissions = components.permissions
+
+        deployer = await getIdentity()
+
+        const created = await worldCreator.createWorldWithScene()
+        worldName = created.worldName
+
+        const deployerAddress = deployer.realAccount.address.toLowerCase()
+        await permissions.grantWorldWidePermission(worldName, 'deployment', [deployerAddress])
+        await permissions.addParcelsToPermission(worldName, 'deployment', deployerAddress, ['20,24'])
       })
 
       it('should respond with 403 unauthorized', async () => {

--- a/test/unit/settings-logic.spec.ts
+++ b/test/unit/settings-logic.spec.ts
@@ -119,11 +119,12 @@ describe('SettingsComponent', () => {
         })
       })
 
-      it('should update the world settings', async () => {
+      it('should update the world settings without checking the world-wide deployment permission', async () => {
         const result = await settingsComponent.updateWorldSettings(worldName, signer, input)
 
         expect(result).toEqual(updatedSettings)
         expect(namePermissionChecker.checkPermission).toHaveBeenCalledWith(signer.toLowerCase(), worldName)
+        expect(permissions.hasWorldWidePermission).not.toHaveBeenCalled()
         expect(worldsManager.updateWorldSettings).toHaveBeenCalledWith(worldName, signer.toLowerCase(), {
           spawnCoordinates: '10,20'
         })
@@ -256,11 +257,15 @@ describe('SettingsComponent', () => {
         })
       })
 
-      it('should update the world settings and check the deployment permission for the normalized signer', async () => {
+      it('should check the name ownership before checking the world-wide deployment permission and update the world settings', async () => {
         const result = await settingsComponent.updateWorldSettings(worldName, signer, input)
 
         expect(result).toEqual(updatedSettings)
+        expect(namePermissionChecker.checkPermission).toHaveBeenCalledWith(signer.toLowerCase(), worldName)
         expect(permissions.hasWorldWidePermission).toHaveBeenCalledWith(worldName, 'deployment', signer.toLowerCase())
+        const nameCheckOrder = namePermissionChecker.checkPermission.mock.invocationCallOrder[0]
+        const worldWideCheckOrder = permissions.hasWorldWidePermission.mock.invocationCallOrder[0]
+        expect(nameCheckOrder).toBeLessThan(worldWideCheckOrder)
       })
     })
 

--- a/test/unit/settings-logic.spec.ts
+++ b/test/unit/settings-logic.spec.ts
@@ -4,6 +4,7 @@ import { IContentStorageComponent, createInMemoryStorage } from '@dcl/catalyst-s
 import { IPublisherComponent } from '@dcl/sns-component'
 import { Events } from '@dcl/schemas'
 import { createSettingsComponent, ISettingsComponent } from '../../src/logic/settings'
+import { IPermissionsComponent } from '../../src/logic/permissions'
 import {
   IWorldNamePermissionChecker,
   IWorldsManager,
@@ -12,6 +13,7 @@ import {
   NoDeployedScenesError
 } from '../../src/types'
 import { createMockedNamePermissionChecker } from '../mocks/dcl-name-checker-mock'
+import { createMockedPermissionsComponent } from '../mocks/permissions-component-mock'
 import { createMockedWorldsManager } from '../mocks/worlds-manager-mock'
 import { createCoordinatesComponent, ICoordinatesComponent } from '../../src/logic/coordinates'
 import { createSnsClientMock } from '../mocks/sns-client-mock'
@@ -21,6 +23,7 @@ describe('SettingsComponent', () => {
   let config: IConfigComponent
   let coordinates: ICoordinatesComponent
   let namePermissionChecker: jest.Mocked<IWorldNamePermissionChecker>
+  let permissions: jest.Mocked<IPermissionsComponent>
   let storage: IContentStorageComponent
   let snsClient: IPublisherComponent
   let worldsManager: jest.Mocked<IWorldsManager>
@@ -32,6 +35,7 @@ describe('SettingsComponent', () => {
     })
     coordinates = createCoordinatesComponent()
     namePermissionChecker = createMockedNamePermissionChecker()
+    permissions = createMockedPermissionsComponent()
     storage = createInMemoryStorage()
     snsClient = createSnsClientMock()
     worldsManager = createMockedWorldsManager()
@@ -40,6 +44,7 @@ describe('SettingsComponent', () => {
       config,
       coordinates,
       namePermissionChecker,
+      permissions,
       storage,
       snsClient,
       worldsManager
@@ -218,11 +223,12 @@ describe('SettingsComponent', () => {
       })
     })
 
-    describe('when the signer does not own the world name', () => {
+    describe('when the signer does not own the world name and does not have world-wide deployment permission', () => {
       beforeEach(() => {
         signer = '0xUnauthorizedAddress'
         input = { spawnCoordinates: '5,10' }
         namePermissionChecker.checkPermission.mockResolvedValue(false)
+        permissions.hasWorldWidePermission.mockResolvedValue(false)
       })
 
       it('should throw an UnauthorizedError with the correct message', async () => {
@@ -232,6 +238,29 @@ describe('SettingsComponent', () => {
             message: 'Unauthorized. You do not have permission to update settings for this world.'
           })
         )
+      })
+    })
+
+    describe('when the signer does not own the world name but has world-wide deployment permission', () => {
+      let updatedSettings: WorldSettings
+
+      beforeEach(() => {
+        signer = '0xWorldWideDeployer'
+        input = { spawnCoordinates: '5,10' }
+        updatedSettings = { spawnCoordinates: '5,10' }
+        namePermissionChecker.checkPermission.mockResolvedValue(false)
+        permissions.hasWorldWidePermission.mockResolvedValue(true)
+        worldsManager.updateWorldSettings.mockResolvedValue({
+          settings: updatedSettings,
+          oldSpawnCoordinates: null
+        })
+      })
+
+      it('should update the world settings and check the deployment permission for the normalized signer', async () => {
+        const result = await settingsComponent.updateWorldSettings(worldName, signer, input)
+
+        expect(result).toEqual(updatedSettings)
+        expect(permissions.hasWorldWidePermission).toHaveBeenCalledWith(worldName, 'deployment', signer.toLowerCase())
       })
     })
 


### PR DESCRIPTION
## Why

Today only the wallet that owns a world's name NFT can update its settings. Owners can already delegate scene deployment to other wallets through the `deployment` allow-list, but settings management remains locked to the owner. Operators want to hand off day-to-day world configuration (title, description, content rating, spawn coordinates, thumbnail, etc.) to trusted collaborators without transferring the underlying name asset.

Granting full settings authority to *every* deployer is too broad — a deployer whose permission is scoped to a handful of parcels has no business changing world-level configuration. So the expansion is targeted: only deployers whose permission is **world-wide** (no parcel scope) gain settings authority. ACL/permissions endpoints are unaffected and still owner-only.

## How

The change lives in the settings logic component (`src/logic/settings/component.ts`). The previous check called `namePermissionChecker.checkPermission(signer, worldName)` and rejected anyone who wasn't the name owner. It now accepts either:

1. The name owner, **or**
2. A wallet with a world-wide deployment permission, verified via the existing `permissions.hasWorldWidePermission(worldName, 'deployment', signer)` primitive.

`hasWorldWidePermission` already encodes the world-wide-vs-parcel-scoped distinction at the database layer (a permission is world-wide when it has zero rows in `world_permission_parcels`), so a deployer whose entry has any parcel rows falls through and still receives `403 Unauthorized`. The settings component now declares `permissions` in its `Pick<AppComponents, …>` and is wired up in `src/components.ts`.

Tests cover both the new positive path and the parcel-scoped negative path:
- Unit (`test/unit/settings-logic.spec.ts`): renamed the existing negative case to make the dual condition explicit, and added a positive case asserting `hasWorldWidePermission` is called with the normalized signer.
- Integration (`test/integration/world-settings-handler.spec.ts`): the prior "deployer with no name ownership" case (which asserted 403) becomes a 200 success; a new parcel-scoped deployer case asserts the 403 is preserved.

## Test plan

- [ ] `yarn build` (typecheck) — passes locally
- [ ] `yarn test test/unit/settings-logic.spec.ts` — passes locally (13/13)
- [ ] CI runs the integration suite (`test/integration/world-settings-handler.spec.ts`) against the real Postgres
- [ ] Manual smoke: as a wallet on the deployment allow-list (no parcel restriction), `PUT /world/:world_name/settings` succeeds; the same wallet with parcels added still receives 403
- [ ] Manual smoke: as a wallet not on the allow-list, `PUT /world/:world_name/settings` still receives 403