### PR TITLE
feat: partial/resumable deploy protocol v2 (Worlds, Phase 1)

### DIFF
--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -1,5 +1,6 @@
 import { Entity } from '@dcl/schemas'
 import { randomBytes } from 'crypto'
+import { hashV1 } from '@dcl/hashing'
 import { InvalidRequestError } from '@dcl/http-commons'
 import {
   AppComponents,
@@ -118,8 +119,41 @@ export function createPartialDeploymentManager(
     })
   }
 
-  async function addFile(_e: string, _h: string, _t: string, _b: Buffer): Promise<void> {
-    throw new Error('not implemented yet')
+  async function addFile(entityId: string, fileHash: string, token: string, bytes: Buffer): Promise<void> {
+    return mutex.run(entityId, async () => {
+      const record = await store.get(entityId)
+      if (!record) {
+        throw new InvalidRequestError(`Deployment ${entityId} not found`)
+      }
+      if (record.expiresAt < Date.now()) {
+        await tempStorage.deleteAll(entityId).catch(() => undefined)
+        await store.delete(entityId)
+        throw new InvalidRequestError(`Deployment ${entityId} expired`)
+      }
+      if (record.deploymentToken !== token) {
+        throw new InvalidRequestError(`Deployment ${entityId} token mismatch`)
+      }
+
+      const computed = await hashV1(bytes)
+      if (computed !== fileHash) {
+        throw new InvalidRequestError(
+          `File hash mismatch: path=${fileHash} computed=${computed}`
+        )
+      }
+      if (!(fileHash in record.manifest)) {
+        throw new InvalidRequestError(
+          `File ${fileHash} not in manifest for deployment ${entityId} (unexpected file)`
+        )
+      }
+      if (record.manifest[fileHash] !== bytes.length) {
+        throw new InvalidRequestError(
+          `File ${fileHash} size mismatch: declared=${record.manifest[fileHash]} actual=${bytes.length}`
+        )
+      }
+
+      await tempStorage.putFile(entityId, fileHash, bytes)
+      await store.markUploaded(entityId, fileHash)
+    })
   }
 
   async function complete(_b: string, _e: string, _t: string): Promise<DeploymentResult> {

--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -24,10 +24,7 @@ type ManagerComponents = Pick<
   | 'logs'
 >
 
-export function createPartialDeploymentManager(
-  components: ManagerComponents,
-  mutex: Mutex
-): IPartialDeploymentManager {
+export function createPartialDeploymentManager(components: ManagerComponents, mutex: Mutex): IPartialDeploymentManager {
   const {
     storage,
     partialDeploymentStore: store,
@@ -41,11 +38,7 @@ export function createPartialDeploymentManager(
     return randomBytes(32).toString('hex')
   }
 
-  function recomputeMissing(
-    manifest: Record<string, number>,
-    uploaded: Set<string>,
-    available: Set<string>
-  ): string[] {
+  function recomputeMissing(manifest: Record<string, number>, uploaded: Set<string>, available: Set<string>): string[] {
     const out: string[] = []
     for (const h of Object.keys(manifest)) {
       if (!uploaded.has(h) && !available.has(h)) out.push(h)
@@ -108,7 +101,11 @@ export function createPartialDeploymentManager(
 
       await store.put(record)
       await tempStorage.putEntityRaw(input.entityId, input.entityRaw)
-      logger.info('Init partial deployment', { entityId: input.entityId, missing: missing.length, available: alreadyAvailable.size })
+      logger.info('Init partial deployment', {
+        entityId: input.entityId,
+        missing: missing.length,
+        available: alreadyAvailable.size
+      })
 
       return {
         availableFiles: Array.from(alreadyAvailable),
@@ -136,14 +133,10 @@ export function createPartialDeploymentManager(
 
       const computed = await hashV1(bytes)
       if (computed !== fileHash) {
-        throw new InvalidRequestError(
-          `File hash mismatch: path=${fileHash} computed=${computed}`
-        )
+        throw new InvalidRequestError(`File hash mismatch: path=${fileHash} computed=${computed}`)
       }
       if (!(fileHash in record.manifest)) {
-        throw new InvalidRequestError(
-          `File ${fileHash} not in manifest for deployment ${entityId} (unexpected file)`
-        )
+        throw new InvalidRequestError(`File ${fileHash} not in manifest for deployment ${entityId} (unexpected file)`)
       }
       if (record.manifest[fileHash] !== bytes.length) {
         throw new InvalidRequestError(

--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -1,0 +1,134 @@
+import { Entity } from '@dcl/schemas'
+import { randomBytes } from 'crypto'
+import { InvalidRequestError } from '@dcl/http-commons'
+import {
+  AppComponents,
+  DeploymentRecord,
+  DeploymentResult,
+  IPartialDeploymentManager,
+  PARTIAL_DEPLOYMENT_TTL_MS,
+  PartialDeploymentInitInput,
+  PartialDeploymentInitResult,
+  PartialDeploymentStatus
+} from '../types'
+import { Mutex } from './partial-deployment-mutex'
+
+type ManagerComponents = Pick<
+  AppComponents,
+  | 'storage'
+  | 'partialDeploymentStore'
+  | 'partialDeploymentTempStorage'
+  | 'partialDeploymentValidator'
+  | 'entityDeployer'
+  | 'logs'
+>
+
+export function createPartialDeploymentManager(
+  components: ManagerComponents,
+  mutex: Mutex
+): IPartialDeploymentManager {
+  const {
+    storage,
+    partialDeploymentStore: store,
+    partialDeploymentTempStorage: tempStorage,
+    partialDeploymentValidator: validator,
+    logs
+  } = components
+  const logger = logs.getLogger('partial-deployment-manager')
+
+  function newToken(): string {
+    return randomBytes(32).toString('hex')
+  }
+
+  function recomputeMissing(
+    manifest: Record<string, number>,
+    uploaded: Set<string>,
+    available: Set<string>
+  ): string[] {
+    const out: string[] = []
+    for (const h of Object.keys(manifest)) {
+      if (!uploaded.has(h) && !available.has(h)) out.push(h)
+    }
+    return out
+  }
+
+  async function init(input: PartialDeploymentInitInput): Promise<PartialDeploymentInitResult> {
+    return mutex.run(input.entityId, async () => {
+      const existing = await store.get(input.entityId)
+      if (existing) {
+        if (existing.ownerAddress.toLowerCase() !== input.ownerAddress.toLowerCase()) {
+          throw new InvalidRequestError(
+            `Deployment ${input.entityId} owner mismatch: cannot re-init from a different wallet`
+          )
+        }
+        return {
+          availableFiles: Array.from(existing.alreadyAvailableHashes),
+          missingFiles: recomputeMissing(existing.manifest, existing.uploadedHashes, existing.alreadyAvailableHashes),
+          deploymentToken: existing.deploymentToken,
+          expiresAt: existing.expiresAt
+        }
+      }
+
+      const entityMetadata = JSON.parse(input.entityRaw.toString())
+      const entity: Entity = { id: input.entityId, timestamp: Date.now(), ...entityMetadata }
+      const contentHashesInStorage = await storage.existMultiple(
+        Array.from(new Set(entity.content?.map(($) => $.hash) ?? []))
+      )
+
+      const preflight = await validator.preflight({
+        entity,
+        authChain: input.authChain,
+        fileSizesManifest: input.manifest,
+        contentHashesInStorage
+      })
+      if (!preflight.ok()) {
+        throw new InvalidRequestError(`Init validation failed: ${preflight.errors.join(', ')}`)
+      }
+
+      const allHashes = Object.keys(input.manifest)
+      const availability = await storage.existMultiple(allHashes)
+      const alreadyAvailable = new Set<string>()
+      const missing: string[] = []
+      for (const h of allHashes) {
+        if (availability.get(h)) alreadyAvailable.add(h)
+        else missing.push(h)
+      }
+
+      const record: DeploymentRecord = {
+        entityId: input.entityId,
+        authChain: input.authChain,
+        ownerAddress: input.ownerAddress,
+        manifest: input.manifest,
+        uploadedHashes: new Set(),
+        alreadyAvailableHashes: alreadyAvailable,
+        deploymentToken: newToken(),
+        expiresAt: Date.now() + PARTIAL_DEPLOYMENT_TTL_MS
+      }
+
+      await store.put(record)
+      await tempStorage.putEntityRaw(input.entityId, input.entityRaw)
+      logger.info('Init partial deployment', { entityId: input.entityId, missing: missing.length, available: alreadyAvailable.size })
+
+      return {
+        availableFiles: Array.from(alreadyAvailable),
+        missingFiles: missing,
+        deploymentToken: record.deploymentToken,
+        expiresAt: record.expiresAt
+      }
+    })
+  }
+
+  async function addFile(_e: string, _h: string, _t: string, _b: Buffer): Promise<void> {
+    throw new Error('not implemented yet')
+  }
+
+  async function complete(_b: string, _e: string, _t: string): Promise<DeploymentResult> {
+    throw new Error('not implemented yet')
+  }
+
+  async function status(_e: string): Promise<PartialDeploymentStatus | undefined> {
+    throw new Error('not implemented yet')
+  }
+
+  return { init, addFile, complete, status }
+}

--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -1,7 +1,7 @@
 import { Entity } from '@dcl/schemas'
 import { randomBytes } from 'crypto'
 import { hashV1 } from '@dcl/hashing'
-import { InvalidRequestError } from '@dcl/http-commons'
+import { InvalidRequestError, NotFoundError } from '@dcl/http-commons'
 import {
   AppComponents,
   DeploymentRecord,
@@ -71,6 +71,7 @@ export function createPartialDeploymentManager(components: ManagerComponents, mu
 
       const preflight = await validator.preflight({
         entity,
+        entityRaw: input.entityRaw,
         authChain: input.authChain,
         fileSizesManifest: input.manifest,
         contentHashesInStorage
@@ -120,12 +121,11 @@ export function createPartialDeploymentManager(components: ManagerComponents, mu
     return mutex.run(entityId, async () => {
       const record = await store.get(entityId)
       if (!record) {
-        throw new InvalidRequestError(`Deployment ${entityId} not found`)
+        throw new NotFoundError(`Deployment ${entityId} not found`)
       }
       if (record.expiresAt < Date.now()) {
-        await tempStorage.deleteAll(entityId).catch(() => undefined)
-        await store.delete(entityId)
-        throw new InvalidRequestError(`Deployment ${entityId} expired`)
+        await deleteAll(record).catch(() => undefined)
+        throw new NotFoundError(`Deployment ${entityId} expired`)
       }
       if (record.deploymentToken !== token) {
         throw new InvalidRequestError(`Deployment ${entityId} token mismatch`)
@@ -162,11 +162,11 @@ export function createPartialDeploymentManager(components: ManagerComponents, mu
     return mutex.run(entityId, async () => {
       const record = await store.get(entityId)
       if (!record) {
-        throw new InvalidRequestError(`Deployment ${entityId} not found`)
+        throw new NotFoundError(`Deployment ${entityId} not found`)
       }
       if (record.expiresAt < Date.now()) {
         await deleteAll(record)
-        throw new InvalidRequestError(`Deployment ${entityId} expired`)
+        throw new NotFoundError(`Deployment ${entityId} expired`)
       }
       if (record.deploymentToken !== token) {
         throw new InvalidRequestError(`Deployment ${entityId} token mismatch`)
@@ -183,6 +183,8 @@ export function createPartialDeploymentManager(components: ManagerComponents, mu
           uploadedFiles.set(h, await tempStorage.getFile(entityId, h))
         }
       }
+      // Validators (including v1) dereference files.get(entity.id) for the entity raw.
+      uploadedFiles.set(entity.id, entityRaw)
 
       const contentHashesInStorage = await storage.existMultiple(Array.from(expectedHashes))
 
@@ -196,18 +198,16 @@ export function createPartialDeploymentManager(components: ManagerComponents, mu
         throw new InvalidRequestError(`Deployment failed: ${validation.errors.join(', ')}`)
       }
 
-      try {
-        return await components.entityDeployer.deployEntity(
-          baseUrl,
-          entity,
-          contentHashesInStorage,
-          uploadedFiles,
-          entityRaw.toString(),
-          record.authChain
-        )
-      } finally {
-        await deleteAll(record).catch((err) => logger.warn('cleanup failed', { err: String(err) }))
-      }
+      const result = await components.entityDeployer.deployEntity(
+        baseUrl,
+        entity,
+        contentHashesInStorage,
+        uploadedFiles,
+        entityRaw.toString(),
+        record.authChain
+      )
+      await deleteAll(record).catch((err) => logger.warn('cleanup failed', { err: String(err) }))
+      return result
     })
   }
 

--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -156,8 +156,66 @@ export function createPartialDeploymentManager(
     })
   }
 
-  async function complete(_b: string, _e: string, _t: string): Promise<DeploymentResult> {
-    throw new Error('not implemented yet')
+  async function deleteAll(record: DeploymentRecord): Promise<void> {
+    const fileKeys = Object.keys(record.manifest).map((h) => `temp/partial/${record.entityId}/${h}`)
+    if (fileKeys.length > 0) {
+      await storage.delete(fileKeys).catch(() => undefined)
+    }
+    await tempStorage.deleteAll(record.entityId).catch(() => undefined)
+    await store.delete(record.entityId)
+  }
+
+  async function complete(baseUrl: string, entityId: string, token: string): Promise<DeploymentResult> {
+    return mutex.run(entityId, async () => {
+      const record = await store.get(entityId)
+      if (!record) {
+        throw new InvalidRequestError(`Deployment ${entityId} not found`)
+      }
+      if (record.expiresAt < Date.now()) {
+        await deleteAll(record)
+        throw new InvalidRequestError(`Deployment ${entityId} expired`)
+      }
+      if (record.deploymentToken !== token) {
+        throw new InvalidRequestError(`Deployment ${entityId} token mismatch`)
+      }
+
+      const entityRaw = await tempStorage.getEntityRaw(entityId)
+      const entityMetadataJson = JSON.parse(entityRaw.toString())
+      const entity: Entity = { id: entityId, timestamp: Date.now(), ...entityMetadataJson }
+      const expectedHashes = new Set(entity.content?.map(($) => $.hash) ?? [])
+
+      const uploadedFiles = new Map<string, Uint8Array>()
+      for (const h of expectedHashes) {
+        if (record.uploadedHashes.has(h)) {
+          uploadedFiles.set(h, await tempStorage.getFile(entityId, h))
+        }
+      }
+
+      const contentHashesInStorage = await storage.existMultiple(Array.from(expectedHashes))
+
+      const validation = await validator.final({
+        entity,
+        files: uploadedFiles,
+        authChain: record.authChain,
+        contentHashesInStorage
+      })
+      if (!validation.ok()) {
+        throw new InvalidRequestError(`Deployment failed: ${validation.errors.join(', ')}`)
+      }
+
+      try {
+        return await components.entityDeployer.deployEntity(
+          baseUrl,
+          entity,
+          contentHashesInStorage,
+          uploadedFiles,
+          entityRaw.toString(),
+          record.authChain
+        )
+      } finally {
+        await deleteAll(record).catch((err) => logger.warn('cleanup failed', { err: String(err) }))
+      }
+    })
   }
 
   async function status(_e: string): Promise<PartialDeploymentStatus | undefined> {

--- a/src/adapters/partial-deployment-manager.ts
+++ b/src/adapters/partial-deployment-manager.ts
@@ -218,8 +218,20 @@ export function createPartialDeploymentManager(
     })
   }
 
-  async function status(_e: string): Promise<PartialDeploymentStatus | undefined> {
-    throw new Error('not implemented yet')
+  async function status(entityId: string): Promise<PartialDeploymentStatus | undefined> {
+    const record = await store.get(entityId)
+    if (!record) return undefined
+    if (record.expiresAt < Date.now()) {
+      await deleteAll(record).catch(() => undefined)
+      return undefined
+    }
+    return {
+      availableFiles: [...record.alreadyAvailableHashes, ...record.uploadedHashes],
+      missingFiles: Object.keys(record.manifest).filter(
+        (h) => !record.uploadedHashes.has(h) && !record.alreadyAvailableHashes.has(h)
+      ),
+      expiresAt: record.expiresAt
+    }
   }
 
   return { init, addFile, complete, status }

--- a/src/adapters/partial-deployment-mutex.ts
+++ b/src/adapters/partial-deployment-mutex.ts
@@ -1,0 +1,23 @@
+export type Mutex = {
+  run<T>(key: string, op: () => Promise<T>): Promise<T>
+}
+
+export function createMutex(): Mutex {
+  const chains = new Map<string, Promise<unknown>>()
+
+  return {
+    async run<T>(key: string, op: () => Promise<T>): Promise<T> {
+      const previous = chains.get(key) ?? Promise.resolve()
+      const next = previous.catch(() => undefined).then(op)
+      chains.set(key, next)
+      try {
+        return await next
+      } finally {
+        // Best-effort cleanup: only remove if still pointing at this run's promise.
+        if (chains.get(key) === next) {
+          chains.delete(key)
+        }
+      }
+    }
+  }
+}

--- a/src/adapters/partial-deployment-store.ts
+++ b/src/adapters/partial-deployment-store.ts
@@ -1,0 +1,37 @@
+import { DeploymentRecord, IPartialDeploymentStore } from '../types'
+
+export function createPartialDeploymentStore(): IPartialDeploymentStore {
+  const records = new Map<string, DeploymentRecord>()
+
+  return {
+    async put(record: DeploymentRecord): Promise<void> {
+      records.set(record.entityId, record)
+    },
+
+    async get(entityId: string): Promise<DeploymentRecord | undefined> {
+      return records.get(entityId)
+    },
+
+    async markUploaded(entityId: string, fileHash: string): Promise<void> {
+      const r = records.get(entityId)
+      if (!r) throw new Error(`Deployment ${entityId} not found`)
+      r.uploadedHashes.add(fileHash)
+    },
+
+    async delete(entityId: string): Promise<void> {
+      records.delete(entityId)
+    },
+
+    async listExpiredBefore(timestamp: number): Promise<string[]> {
+      const out: string[] = []
+      for (const [entityId, r] of records) {
+        if (r.expiresAt < timestamp) out.push(entityId)
+      }
+      return out
+    },
+
+    async clear(): Promise<void> {
+      records.clear()
+    }
+  }
+}

--- a/src/adapters/partial-deployment-sweeper.ts
+++ b/src/adapters/partial-deployment-sweeper.ts
@@ -1,0 +1,49 @@
+import { AppComponents, IPartialDeploymentSweeper } from '../types'
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+
+export type SweeperOptions = {
+  intervalMs?: number
+  onCleanupExpiredEntity: (entityId: string) => Promise<void>
+}
+
+export function createPartialDeploymentSweeper(
+  components: Pick<AppComponents, 'partialDeploymentStore' | 'logs'>,
+  options: SweeperOptions
+): IPartialDeploymentSweeper & { runOnce(): Promise<void> } {
+  const { partialDeploymentStore: store, logs } = components
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS
+  const logger = logs.getLogger('partial-deployment-sweeper')
+
+  let timer: NodeJS.Timeout | undefined
+
+  async function runOnce(): Promise<void> {
+    const expired = await store.listExpiredBefore(Date.now())
+    for (const entityId of expired) {
+      try {
+        await options.onCleanupExpiredEntity(entityId)
+      } catch (err: any) {
+        logger.warn(`Cleanup of ${entityId} failed`, { err: String(err) })
+      } finally {
+        await store.delete(entityId)
+      }
+    }
+    if (expired.length > 0) {
+      logger.info(`Swept ${expired.length} expired partial deployments`)
+    }
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (timer) return
+      timer = setInterval(() => {
+        runOnce().catch((err) => logger.error(`sweep tick failed`, { err: String(err) }))
+      }, intervalMs)
+    },
+    async stop(): Promise<void> {
+      if (timer) clearInterval(timer)
+      timer = undefined
+    },
+    runOnce
+  }
+}

--- a/src/adapters/partial-deployment-temp-storage.ts
+++ b/src/adapters/partial-deployment-temp-storage.ts
@@ -1,0 +1,49 @@
+import { bufferToStream, IContentStorageComponent, streamToBuffer } from '@dcl/catalyst-storage'
+import { IPartialDeploymentTempStorage } from '../types'
+
+const TEMP_PREFIX = 'temp/partial'
+
+function entityRawKey(entityId: string): string {
+  return `${TEMP_PREFIX}/${entityId}/.entity`
+}
+
+function fileKey(entityId: string, fileHash: string): string {
+  return `${TEMP_PREFIX}/${entityId}/${fileHash}`
+}
+
+export function createPartialDeploymentTempStorage(
+  components: { storage: IContentStorageComponent }
+): IPartialDeploymentTempStorage {
+  const { storage } = components
+
+  return {
+    async putEntityRaw(entityId, bytes) {
+      await storage.storeStream(entityRawKey(entityId), bufferToStream(bytes))
+    },
+
+    async putFile(entityId, fileHash, bytes) {
+      await storage.storeStream(fileKey(entityId, fileHash), bufferToStream(bytes))
+    },
+
+    async getEntityRaw(entityId) {
+      const item = await storage.retrieve(entityRawKey(entityId))
+      if (!item) throw new Error(`Temp entity-raw not found: ${entityId}`)
+      return streamToBuffer(await item.asStream())
+    },
+
+    async getFile(entityId, fileHash) {
+      const item = await storage.retrieve(fileKey(entityId, fileHash))
+      if (!item) throw new Error(`Temp file not found: ${entityId}/${fileHash}`)
+      return streamToBuffer(await item.asStream())
+    },
+
+    async deleteAll(entityId) {
+      // Best-effort: delete the entity-raw key. Per-file blobs are deleted by
+      // the manager (which knows the manifest hashes) via storage.delete([keys]).
+      const item = await storage.retrieve(entityRawKey(entityId))
+      if (item) {
+        await storage.delete([entityRawKey(entityId)])
+      }
+    }
+  }
+}

--- a/src/adapters/partial-deployment-temp-storage.ts
+++ b/src/adapters/partial-deployment-temp-storage.ts
@@ -11,9 +11,9 @@ function fileKey(entityId: string, fileHash: string): string {
   return `${TEMP_PREFIX}/${entityId}/${fileHash}`
 }
 
-export function createPartialDeploymentTempStorage(
-  components: { storage: IContentStorageComponent }
-): IPartialDeploymentTempStorage {
+export function createPartialDeploymentTempStorage(components: {
+  storage: IContentStorageComponent
+}): IPartialDeploymentTempStorage {
   const { storage } = components
 
   return {

--- a/src/components.ts
+++ b/src/components.ts
@@ -69,6 +69,12 @@ import { createRateLimiterComponent } from './logic/rate-limiter'
 import { createDenyListComponent } from './logic/denylist'
 import { createBansComponent } from './adapters/bans-adapter'
 import { createEvictionJob } from './adapters/eviction-job'
+import { createPartialDeploymentStore } from './adapters/partial-deployment-store'
+import { createPartialDeploymentTempStorage } from './adapters/partial-deployment-temp-storage'
+import { createMutex } from './adapters/partial-deployment-mutex'
+import { createPartialDeploymentManager } from './adapters/partial-deployment-manager'
+import { createPartialDeploymentSweeper } from './adapters/partial-deployment-sweeper'
+import { createPartialDeploymentValidator } from './logic/validations/partial-deployment-validator'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -200,6 +206,44 @@ export async function initComponents(): Promise<AppComponents> {
     worldsManager
   })
 
+  const partialDeploymentStore = createPartialDeploymentStore()
+  const partialDeploymentTempStorage = createPartialDeploymentTempStorage({ storage })
+  const partialDeploymentValidator = createPartialDeploymentValidator({
+    config,
+    limitsManager,
+    nameDenyListChecker,
+    namePermissionChecker,
+    permissions,
+    storage,
+    worldsManager
+  })
+  const partialDeploymentMutex = createMutex()
+  const partialDeploymentManager = createPartialDeploymentManager(
+    {
+      storage,
+      partialDeploymentStore,
+      partialDeploymentTempStorage,
+      partialDeploymentValidator,
+      entityDeployer,
+      logs
+    },
+    partialDeploymentMutex
+  )
+  const partialDeploymentSweeper = createPartialDeploymentSweeper(
+    { partialDeploymentStore, logs },
+    {
+      onCleanupExpiredEntity: async (entityId) => {
+        const record = await partialDeploymentStore.get(entityId)
+        if (!record) return
+        const fileKeys = Object.keys(record.manifest).map((h) => `temp/partial/${entityId}/${h}`)
+        if (fileKeys.length > 0) {
+          await storage.delete(fileKeys).catch(() => undefined)
+        }
+        await partialDeploymentTempStorage.deleteAll(entityId).catch(() => undefined)
+      }
+    }
+  )
+
   const migrationExecutor = createMigrationExecutor({ logs, database: database, nameOwnership, storage, worldsManager })
 
   const notificationService = await createNotificationsClientComponent({ config, fetch, logs })
@@ -305,6 +349,11 @@ export async function initComponents(): Promise<AppComponents> {
     bans,
     worlds,
     worldsIndexer,
-    worldsManager
-  } as unknown as AppComponents
+    worldsManager,
+    partialDeploymentStore,
+    partialDeploymentTempStorage,
+    partialDeploymentManager,
+    partialDeploymentSweeper,
+    partialDeploymentValidator
+  }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,13 +8,7 @@ import { createLogComponent } from '@well-known-components/logger'
 import { createFetchComponent } from '@dcl/platform-server-commons'
 import { createMetricsComponent } from '@well-known-components/metrics'
 import { createSubgraphComponent } from '@well-known-components/thegraph-component'
-import {
-  AppComponents,
-  GlobalContext,
-  ICommsAdapter,
-  INameDenyListChecker,
-  IWorldNamePermissionChecker
-} from './types'
+import { AppComponents, GlobalContext, ICommsAdapter, INameDenyListChecker, IWorldNamePermissionChecker } from './types'
 import { metricDeclarations } from './metrics'
 import { HTTPProvider } from 'eth-connect'
 import {

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,7 +8,13 @@ import { createLogComponent } from '@well-known-components/logger'
 import { createFetchComponent } from '@dcl/platform-server-commons'
 import { createMetricsComponent } from '@well-known-components/metrics'
 import { createSubgraphComponent } from '@well-known-components/thegraph-component'
-import { AppComponents, GlobalContext, ICommsAdapter, INameDenyListChecker, IWorldNamePermissionChecker } from './types'
+import {
+  AppComponents,
+  GlobalContext,
+  ICommsAdapter,
+  INameDenyListChecker,
+  IWorldNamePermissionChecker
+} from './types'
 import { metricDeclarations } from './metrics'
 import { HTTPProvider } from 'eth-connect'
 import {
@@ -300,5 +306,5 @@ export async function initComponents(): Promise<AppComponents> {
     worlds,
     worldsIndexer,
     worldsManager
-  }
+  } as unknown as AppComponents
 }

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -4,6 +4,7 @@ import { FormDataContext } from '../../logic/multipart'
 import { HandlerContextWithPath } from '../../types'
 import { extractAuthChain } from '../../logic/extract-auth-chain'
 import { InvalidRequestError } from '@dcl/http-commons'
+import { initPartialDeployment } from './deploy-v2-handlers'
 
 export function requireString(val: string | null | undefined): string {
   if (typeof val !== 'string') throw new InvalidRequestError('A string was expected')
@@ -11,8 +12,18 @@ export function requireString(val: string | null | undefined): string {
 }
 
 export async function deployEntity(
-  ctx: FormDataContext & HandlerContextWithPath<'config' | 'entityDeployer' | 'storage' | 'validator', '/entities'>
+  ctx: FormDataContext &
+    HandlerContextWithPath<
+      'config' | 'entityDeployer' | 'storage' | 'validator' | 'partialDeploymentManager',
+      '/entities'
+    >
 ): Promise<IHttpServerComponent.IResponse> {
+  // v2 init dispatch — capability-based, no /v2/ URL namespace
+  if (ctx.request.headers.get('upload-incomplete') === '?1') {
+    return initPartialDeployment(ctx as any)
+  }
+
+  // ===== v1 path (unchanged below this line) =====
   const entityId = requireString(ctx.formData.fields.entityId?.value[0])
   const authChain = extractAuthChain(ctx)
 

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -20,7 +20,7 @@ export async function deployEntity(
 ): Promise<IHttpServerComponent.IResponse> {
   // v2 init dispatch — capability-based, no /v2/ URL namespace
   if (ctx.request.headers.get('upload-incomplete') === '?1') {
-    return initPartialDeployment(ctx as any)
+    return initPartialDeployment(ctx)
   }
 
   // ===== v1 path (unchanged below this line) =====

--- a/src/controllers/handlers/deploy-v2-handlers.ts
+++ b/src/controllers/handlers/deploy-v2-handlers.ts
@@ -1,7 +1,7 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { InvalidRequestError } from '@dcl/http-commons'
 import { FormDataContext } from '../../logic/multipart'
-import { HandlerContextWithPath } from '../../types'
+import { HandlerContextWithPath, PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES } from '../../types'
 import { extractAuthChain } from '../../logic/extract-auth-chain'
 
 const TOKEN_HEADER = 'x-deployment-token'
@@ -62,6 +62,20 @@ export async function addFileToPartialDeployment(
   const fileHash = ctx.params.fileHash
   const token = ctx.request.headers.get(TOKEN_HEADER)
   if (!token) throw new InvalidRequestError(`Missing ${TOKEN_HEADER} header`)
+
+  const contentLengthHeader = ctx.request.headers.get('content-length')
+  if (!contentLengthHeader) {
+    throw new InvalidRequestError('Content-Length header required')
+  }
+  const contentLength = Number(contentLengthHeader)
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    throw new InvalidRequestError('Content-Length header invalid')
+  }
+  if (contentLength > PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES) {
+    throw new InvalidRequestError(
+      `File too large: declared ${contentLength} bytes exceeds limit ${PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES}`
+    )
+  }
 
   const buffer = await ctx.request.buffer()
   await ctx.components.partialDeploymentManager.addFile(entityId, fileHash, token, buffer)

--- a/src/controllers/handlers/deploy-v2-handlers.ts
+++ b/src/controllers/handlers/deploy-v2-handlers.ts
@@ -1,0 +1,97 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { InvalidRequestError } from '@dcl/http-commons'
+import { FormDataContext } from '../../logic/multipart'
+import { HandlerContextWithPath } from '../../types'
+import { extractAuthChain } from '../../logic/extract-auth-chain'
+
+const TOKEN_HEADER = 'x-deployment-token'
+
+/** Init: dispatched here by deployEntity when it sees Upload-Incomplete: ?1 */
+export async function initPartialDeployment(
+  ctx: FormDataContext &
+    HandlerContextWithPath<'partialDeploymentManager', '/entities'>
+): Promise<IHttpServerComponent.IResponse> {
+  const entityIdRaw = ctx.formData.fields.entityId?.value[0]
+  if (typeof entityIdRaw !== 'string') {
+    throw new InvalidRequestError('entityId is required')
+  }
+  const entityId = entityIdRaw
+  const authChain = extractAuthChain(ctx)
+
+  const entityFile = ctx.formData.files[entityId]
+  if (!entityFile) {
+    throw new InvalidRequestError(`Entity file ${entityId} missing in init multipart`)
+  }
+  const entityRaw = entityFile.value as Buffer
+
+  const manifestRaw = ctx.formData.fields.fileSizesManifest?.value[0]
+  if (typeof manifestRaw !== 'string') {
+    throw new InvalidRequestError('fileSizesManifest field is required')
+  }
+  let manifest: Record<string, number>
+  try {
+    manifest = JSON.parse(manifestRaw)
+  } catch {
+    throw new InvalidRequestError('fileSizesManifest is not valid JSON')
+  }
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    throw new InvalidRequestError('fileSizesManifest must be a JSON object')
+  }
+
+  const ownerAddress = (authChain[0]?.payload || '').toLowerCase()
+  if (!ownerAddress) throw new InvalidRequestError('authChain payload missing')
+
+  const result = await ctx.components.partialDeploymentManager.init({
+    entityId,
+    entityRaw,
+    authChain,
+    ownerAddress,
+    manifest
+  })
+
+  return {
+    status: 202,
+    body: result
+  }
+}
+
+/** POST /entities/:entityId/files/:fileHash */
+export async function addFileToPartialDeployment(
+  ctx: HandlerContextWithPath<'partialDeploymentManager', '/entities/:entityId/files/:fileHash'>
+): Promise<IHttpServerComponent.IResponse> {
+  const entityId = ctx.params.entityId
+  const fileHash = ctx.params.fileHash
+  const token = ctx.request.headers.get(TOKEN_HEADER)
+  if (!token) throw new InvalidRequestError(`Missing ${TOKEN_HEADER} header`)
+
+  const buffer = await ctx.request.buffer()
+  await ctx.components.partialDeploymentManager.addFile(entityId, fileHash, token, buffer)
+  return { status: 204, body: '' }
+}
+
+/** POST /entities/:entityId */
+export async function finalizePartialDeployment(
+  ctx: HandlerContextWithPath<'config' | 'partialDeploymentManager', '/entities/:entityId'>
+): Promise<IHttpServerComponent.IResponse> {
+  const entityId = ctx.params.entityId
+  const token = ctx.request.headers.get(TOKEN_HEADER)
+  if (!token) throw new InvalidRequestError(`Missing ${TOKEN_HEADER} header`)
+
+  const baseUrl = (await ctx.components.config.getString('HTTP_BASE_URL')) || `https://${ctx.url.host}`
+  const result = await ctx.components.partialDeploymentManager.complete(baseUrl, entityId, token)
+  return {
+    status: 200,
+    body: { creationTimestamp: Date.now(), ...result }
+  }
+}
+
+/** GET /entities/:entityId/status */
+export async function getPartialDeploymentStatus(
+  ctx: HandlerContextWithPath<'partialDeploymentManager', '/entities/:entityId/status'>
+): Promise<IHttpServerComponent.IResponse> {
+  const status = await ctx.components.partialDeploymentManager.status(ctx.params.entityId)
+  if (!status) {
+    return { status: 404, body: { error: 'not found' } }
+  }
+  return { status: 200, body: status }
+}

--- a/src/controllers/handlers/deploy-v2-handlers.ts
+++ b/src/controllers/handlers/deploy-v2-handlers.ts
@@ -8,8 +8,7 @@ const TOKEN_HEADER = 'x-deployment-token'
 
 /** Init: dispatched here by deployEntity when it sees Upload-Incomplete: ?1 */
 export async function initPartialDeployment(
-  ctx: FormDataContext &
-    HandlerContextWithPath<'partialDeploymentManager', '/entities'>
+  ctx: FormDataContext & HandlerContextWithPath<'partialDeploymentManager', '/entities'>
 ): Promise<IHttpServerComponent.IResponse> {
   const entityIdRaw = ctx.formData.fields.entityId?.value[0]
   if (typeof entityIdRaw !== 'string') {

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -39,6 +39,11 @@ import { getWorldsHandler } from './handlers/worlds-handler'
 import { reprocessABSchema } from './schemas/reprocess-ab-schemas'
 import { getWorldScenesSchema } from './schemas/scenes-query-schemas'
 import { worldCommsHandler } from './handlers/world-comms-handler'
+import {
+  addFileToPartialDeployment,
+  finalizePartialDeployment,
+  getPartialDeploymentStatus
+} from './handlers/deploy-v2-handlers'
 
 export async function setupRouter(globalContext: GlobalContext): Promise<Router<GlobalContext>> {
   const { fetch, schemaValidator, config } = globalContext.components
@@ -89,6 +94,12 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/ipfs/:hashId', getContentFile)
 
   router.post('/entities/active', activeEntitiesHandler)
+
+  // v2 partial-deployment sub-routes
+  router.post('/entities/:entityId/files/:fileHash', addFileToPartialDeployment)
+  router.post('/entities/:entityId', finalizePartialDeployment)
+  router.get('/entities/:entityId/status', getPartialDeploymentStatus)
+
   router.head('/contents/:hashId', headContentFile)
   router.get('/contents/:hashId', getContentFile)
 

--- a/src/logic/validations/partial-deployment-validator.ts
+++ b/src/logic/validations/partial-deployment-validator.ts
@@ -1,0 +1,28 @@
+import { IPartialDeploymentValidator, ValidationResult, Validator, ValidatorComponents } from '../../types'
+import { createValidator } from './validator'
+
+/**
+ * Wraps the existing v1 Validator. preflight runs at init (no file bytes yet);
+ * final runs at finalize (full validation including auth-chain). Both delegate
+ * to the same v1 validator — the distinction is *when*, not *what*.
+ */
+export function createPartialDeploymentValidator(
+  components: ValidatorComponents
+): IPartialDeploymentValidator {
+  const v1Validator: Validator = createValidator(components)
+
+  return {
+    async preflight(input): Promise<ValidationResult> {
+      return v1Validator.validate({
+        entity: input.entity,
+        files: new Map(), // no file bytes available at init time
+        authChain: input.authChain,
+        contentHashesInStorage: input.contentHashesInStorage
+      })
+    },
+
+    async final(deployment): Promise<ValidationResult> {
+      return v1Validator.validate(deployment)
+    }
+  }
+}

--- a/src/logic/validations/partial-deployment-validator.ts
+++ b/src/logic/validations/partial-deployment-validator.ts
@@ -5,19 +5,20 @@ import {
   Validator,
   ValidatorComponents
 } from '../../types'
-import { createValidator } from './validator'
+import { createCommonValidations, createValidator } from './validator'
+import { OK } from './utils'
 
 /**
- * Wraps the existing v1 Validator. preflight runs at init (no file bytes yet);
- * final runs at finalize (full validation including auth-chain). Both delegate
- * to the same v1 validator — the distinction is *when*, not *what*.
+ * preflight runs at init time and only executes validations that don't require
+ * content file bytes (signer, entity well-formedness, scene metadata, name
+ * permission). final runs at finalize and delegates to the full v1 validator.
  */
 export function createPartialDeploymentValidator(components: ValidatorComponents): IPartialDeploymentValidator {
   const v1Validator: Validator = createValidator(components)
+  const preflightValidations = createCommonValidations(components)
 
   return {
     async preflight(input): Promise<ValidationResult> {
-      // Reject oversized individual files before accepting any blobs.
       const oversized: string[] = []
       for (const [hash, size] of Object.entries(input.fileSizesManifest)) {
         if (size > PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES) {
@@ -31,12 +32,17 @@ export function createPartialDeploymentValidator(components: ValidatorComponents
         return { ok: () => false, errors }
       }
 
-      return v1Validator.validate({
+      const deployment = {
         entity: input.entity,
         files: new Map([[input.entity.id, input.entityRaw]]),
         authChain: input.authChain,
         contentHashesInStorage: input.contentHashesInStorage
-      })
+      }
+      for (const validation of preflightValidations) {
+        const result = await validation(deployment)
+        if (!result.ok()) return result
+      }
+      return OK
     },
 
     async final(deployment): Promise<ValidationResult> {

--- a/src/logic/validations/partial-deployment-validator.ts
+++ b/src/logic/validations/partial-deployment-validator.ts
@@ -6,9 +6,7 @@ import { createValidator } from './validator'
  * final runs at finalize (full validation including auth-chain). Both delegate
  * to the same v1 validator — the distinction is *when*, not *what*.
  */
-export function createPartialDeploymentValidator(
-  components: ValidatorComponents
-): IPartialDeploymentValidator {
+export function createPartialDeploymentValidator(components: ValidatorComponents): IPartialDeploymentValidator {
   const v1Validator: Validator = createValidator(components)
 
   return {

--- a/src/logic/validations/partial-deployment-validator.ts
+++ b/src/logic/validations/partial-deployment-validator.ts
@@ -1,4 +1,10 @@
-import { IPartialDeploymentValidator, ValidationResult, Validator, ValidatorComponents } from '../../types'
+import {
+  IPartialDeploymentValidator,
+  PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES,
+  ValidationResult,
+  Validator,
+  ValidatorComponents
+} from '../../types'
 import { createValidator } from './validator'
 
 /**
@@ -11,9 +17,23 @@ export function createPartialDeploymentValidator(components: ValidatorComponents
 
   return {
     async preflight(input): Promise<ValidationResult> {
+      // Reject oversized individual files before accepting any blobs.
+      const oversized: string[] = []
+      for (const [hash, size] of Object.entries(input.fileSizesManifest)) {
+        if (size > PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES) {
+          oversized.push(`${hash} (${size} bytes)`)
+        }
+      }
+      if (oversized.length > 0) {
+        const errors = [
+          `Files exceed per-file size limit (${PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES} bytes): ${oversized.join(', ')}`
+        ]
+        return { ok: () => false, errors }
+      }
+
       return v1Validator.validate({
         entity: input.entity,
-        files: new Map(), // no file bytes available at init time
+        files: new Map([[input.entity.id, input.entityRaw]]),
         authChain: input.authChain,
         contentHashesInStorage: input.contentHashesInStorage
       })

--- a/src/logic/validations/validator.ts
+++ b/src/logic/validations/validator.ts
@@ -23,9 +23,13 @@ import {
 import { OK, validateAll, validateIfTypeMatches } from './utils'
 import { EntityType } from '@dcl/schemas'
 
-export function createValidateFns(components: ValidatorComponents): Validation[] {
+/**
+ * Validations safe to run at partial-deployment init (preflight), when only the
+ * entity raw is available and content file bytes have not yet been uploaded.
+ * They depend on entity metadata, auth chain, or `files.get(entity.id)` only.
+ */
+export function createCommonValidations(components: ValidatorComponents): Validation[] {
   return [
-    // Common validations to all entity types
     validateAll([
       validateEntityId,
       validateBaseEntity,
@@ -33,11 +37,9 @@ export function createValidateFns(components: ValidatorComponents): Validation[]
       validateSigner,
       validateSignature,
       createValidateDeploymentTtl(components),
-      validateFiles,
       validateSupportedEntityType
     ]),
 
-    // Scene entity validations
     validateIfTypeMatches(
       EntityType.SCENE,
       validateAll([
@@ -49,13 +51,22 @@ export function createValidateFns(components: ValidatorComponents): Validation[]
         validateThumbnail,
         createValidateBannedNames(components),
         // validateSdkVersion(components) TODO re-enable (and test) once SDK7 is ready
-        createValidateSize(components), // Slow
         createValidateDeploymentPermission(components) // Slow
       ])
     )
-
-    // Other entity validations will go here ...
   ]
+}
+
+/**
+ * Validations that require every content file to be present (uploaded or
+ * already in storage). Only runnable at finalize.
+ */
+export function createFinalOnlyValidations(components: ValidatorComponents): Validation[] {
+  return [validateFiles, validateIfTypeMatches(EntityType.SCENE, createValidateSize(components))]
+}
+
+export function createValidateFns(components: ValidatorComponents): Validation[] {
+  return [...createCommonValidations(components), ...createFinalOnlyValidations(components)]
 }
 
 export const createValidator = (components: ValidatorComponents): Validator => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ import { IDenyListComponent } from './logic/denylist/types'
 import { IBansComponent } from './adapters/bans-adapter'
 
 export type GlobalContext = {
-  components: BaseComponents
+  components: AppComponents
 }
 
 export const MB = 1024 * 1024

--- a/src/types.ts
+++ b/src/types.ts
@@ -575,6 +575,11 @@ export type IWorldCreator = {
 // components used in runtime
 export type AppComponents = BaseComponents & {
   statusChecks: IBaseComponent
+  partialDeploymentStore: IPartialDeploymentStore
+  partialDeploymentTempStorage: IPartialDeploymentTempStorage
+  partialDeploymentManager: IPartialDeploymentManager
+  partialDeploymentSweeper: IPartialDeploymentSweeper
+  partialDeploymentValidator: IPartialDeploymentValidator
 }
 
 // this type simplifies the typings of http handlers
@@ -652,3 +657,90 @@ export type PaginatedResult<T> = {
 }
 
 export type ParcelsResult = PaginatedResult<string>
+
+// ============================================================================
+// Partial / resumable deployment (v2 protocol) — Phase 1
+// ============================================================================
+
+/** TTL after which a stale in-flight deployment is evicted. */
+export const PARTIAL_DEPLOYMENT_TTL_MS = 15 * 60 * 1000
+
+/** Default per-file upload size limit. */
+export const PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES = 100 * 1024 * 1024
+
+export type DeploymentRecord = {
+  entityId: string
+  authChain: AuthChain
+  ownerAddress: EthAddress
+  /** Manifest of file hash → declared byte size, taken verbatim from the init request. */
+  manifest: Record<string, number>
+  /** Hashes the server has already received under this deployment. Initially empty. */
+  uploadedHashes: Set<string>
+  /** Hashes that were already in storage before init (won't be re-uploaded). */
+  alreadyAvailableHashes: Set<string>
+  /** Random opaque correlator the client must send on subsequent calls. */
+  deploymentToken: string
+  /** Wall-clock ms after which this deployment must be evicted. */
+  expiresAt: number
+}
+
+export type IPartialDeploymentStore = {
+  put(record: DeploymentRecord): Promise<void>
+  get(entityId: string): Promise<DeploymentRecord | undefined>
+  markUploaded(entityId: string, fileHash: string): Promise<void>
+  delete(entityId: string): Promise<void>
+  /** Returns entityIds with `expiresAt < timestamp`. */
+  listExpiredBefore(timestamp: number): Promise<string[]>
+  /** For tests. */
+  clear(): Promise<void>
+}
+
+export type IPartialDeploymentTempStorage = {
+  putEntityRaw(entityId: string, bytes: Buffer): Promise<void>
+  putFile(entityId: string, fileHash: string, bytes: Buffer): Promise<void>
+  getEntityRaw(entityId: string): Promise<Buffer>
+  getFile(entityId: string, fileHash: string): Promise<Buffer>
+  deleteAll(entityId: string): Promise<void>
+}
+
+export type PartialDeploymentInitInput = {
+  entityId: string
+  entityRaw: Buffer
+  authChain: AuthChain
+  ownerAddress: EthAddress
+  manifest: Record<string, number>
+}
+
+export type PartialDeploymentInitResult = {
+  availableFiles: string[]
+  missingFiles: string[]
+  deploymentToken: string
+  expiresAt: number
+}
+
+export type PartialDeploymentStatus = {
+  availableFiles: string[]
+  missingFiles: string[]
+  expiresAt: number
+}
+
+export type IPartialDeploymentManager = {
+  init(input: PartialDeploymentInitInput): Promise<PartialDeploymentInitResult>
+  addFile(entityId: string, fileHash: string, token: string, bytes: Buffer): Promise<void>
+  complete(baseUrl: string, entityId: string, token: string): Promise<DeploymentResult>
+  status(entityId: string): Promise<PartialDeploymentStatus | undefined>
+}
+
+export type IPartialDeploymentSweeper = IBaseComponent
+
+export type IPartialDeploymentValidator = {
+  /** Light-weight pre-checks runnable at init: scene-size, signer permissions, per-file size. No file bytes needed. */
+  preflight(input: {
+    entity: Entity
+    authChain: AuthChain
+    fileSizesManifest: Record<string, number>
+    contentHashesInStorage: Map<string, boolean>
+  }): Promise<ValidationResult>
+  /** Full validation runnable at finalize: re-runs all checks, including auth-chain verification. */
+  final(deployment: DeploymentToValidate): Promise<ValidationResult>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -737,6 +737,7 @@ export type IPartialDeploymentValidator = {
   /** Light-weight pre-checks runnable at init: scene-size, signer permissions, per-file size. No file bytes needed. */
   preflight(input: {
     entity: Entity
+    entityRaw: Buffer
     authChain: AuthChain
     fileSizesManifest: Record<string, number>
     contentHashesInStorage: Map<string, boolean>

--- a/test/components.ts
+++ b/test/components.ts
@@ -47,6 +47,12 @@ import { createRedisMock } from './mocks/redis-mock'
 import { createRateLimiterComponent } from '../src/logic/rate-limiter'
 import { createMockDenyList } from './mocks/denylist-mock'
 import { createMockBans } from './mocks/bans-mock'
+import { createPartialDeploymentStore } from '../src/adapters/partial-deployment-store'
+import { createPartialDeploymentTempStorage } from '../src/adapters/partial-deployment-temp-storage'
+import { createMutex } from '../src/adapters/partial-deployment-mutex'
+import { createPartialDeploymentManager } from '../src/adapters/partial-deployment-manager'
+import { createPartialDeploymentSweeper } from '../src/adapters/partial-deployment-sweeper'
+import { createPartialDeploymentValidator } from '../src/logic/validations/partial-deployment-validator'
 
 /**
  * Behaves like Jest "describe" function, used to describe a test for a
@@ -200,6 +206,45 @@ async function initComponents(): Promise<TestComponents> {
 
   const queueConsumer = createMockQueueConsumer()
 
+  const partialDeploymentStore = createPartialDeploymentStore()
+  const partialDeploymentTempStorage = createPartialDeploymentTempStorage({ storage })
+  const partialDeploymentValidator = createPartialDeploymentValidator({
+    config,
+    limitsManager,
+    nameDenyListChecker,
+    namePermissionChecker,
+    permissions,
+    storage,
+    worldsManager
+  })
+  const partialDeploymentMutex = createMutex()
+  const partialDeploymentManager = createPartialDeploymentManager(
+    {
+      storage,
+      partialDeploymentStore,
+      partialDeploymentTempStorage,
+      partialDeploymentValidator,
+      entityDeployer,
+      logs
+    },
+    partialDeploymentMutex
+  )
+  const partialDeploymentSweeper = createPartialDeploymentSweeper(
+    { partialDeploymentStore, logs },
+    {
+      intervalMs: 60_000_000,
+      onCleanupExpiredEntity: async (entityId) => {
+        const record = await partialDeploymentStore.get(entityId)
+        if (!record) return
+        const fileKeys = Object.keys(record.manifest).map((h) => `temp/partial/${entityId}/${h}`)
+        if (fileKeys.length > 0) {
+          await storage.delete(fileKeys).catch(() => undefined)
+        }
+        await partialDeploymentTempStorage.deleteAll(entityId).catch(() => undefined)
+      }
+    }
+  )
+
   return {
     ...components,
     access,
@@ -236,6 +281,11 @@ async function initComponents(): Promise<TestComponents> {
     worldCreator,
     worlds,
     worldsIndexer,
-    worldsManager
+    worldsManager,
+    partialDeploymentStore,
+    partialDeploymentTempStorage,
+    partialDeploymentManager,
+    partialDeploymentSweeper,
+    partialDeploymentValidator
   }
 }

--- a/test/integration/deploy-v2-failures.spec.ts
+++ b/test/integration/deploy-v2-failures.spec.ts
@@ -26,9 +26,7 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
     const identity = await getIdentity()
     const worldName = worldCreator.randomWorldName()
 
-    namePermissionChecker.checkPermission
-      .withArgs(identity.authChain.authChain[0].payload, worldName)
-      .resolves(true)
+    namePermissionChecker.checkPermission.withArgs(identity.authChain.authChain[0].payload, worldName).resolves(true)
     nameOwnership.findOwners
       .withArgs([worldName])
       .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
@@ -92,14 +90,17 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
   it('404 (or 400) on file upload to unknown entity', async () => {
     const { localFetch } = components
 
-    const resp = await localFetch.fetch('/entities/QmUnknownEntity000000000000000000000000000000001/files/QmUnknownFile0000000000000000000000000000000001', {
-      method: 'POST',
-      headers: {
-        'X-Deployment-Token': 'some-token',
-        'Content-Type': 'application/octet-stream'
-      },
-      body: Buffer.from('x') as any
-    })
+    const resp = await localFetch.fetch(
+      '/entities/QmUnknownEntity000000000000000000000000000000001/files/QmUnknownFile0000000000000000000000000000000001',
+      {
+        method: 'POST',
+        headers: {
+          'X-Deployment-Token': 'some-token',
+          'Content-Type': 'application/octet-stream'
+        },
+        body: Buffer.from('x') as any
+      }
+    )
 
     expect([400, 404]).toContain(resp.status)
   })
@@ -225,9 +226,7 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
   it('GET /entities/:entityId/status returns 404 for an unknown entity', async () => {
     const { localFetch } = components
 
-    const statusResp = await localFetch.fetch(
-      '/entities/QmUnknownEntity000000000000000000000000000000001/status'
-    )
+    const statusResp = await localFetch.fetch('/entities/QmUnknownEntity000000000000000000000000000000001/status')
     expect(statusResp.status).toBe(404)
   })
 })

--- a/test/integration/deploy-v2-failures.spec.ts
+++ b/test/integration/deploy-v2-failures.spec.ts
@@ -87,7 +87,7 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
     return { entityId, contentBuf, contentHash, token: initBody.deploymentToken }
   }
 
-  it('404 (or 400) on file upload to unknown entity', async () => {
+  it('404 on file upload to unknown entity', async () => {
     const { localFetch } = components
 
     const resp = await localFetch.fetch(
@@ -96,16 +96,17 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
         method: 'POST',
         headers: {
           'X-Deployment-Token': 'some-token',
+          'Content-Length': '1',
           'Content-Type': 'application/octet-stream'
         },
         body: Buffer.from('x') as any
       }
     )
 
-    expect([400, 404]).toContain(resp.status)
+    expect(resp.status).toBe(404)
   })
 
-  it('400 (or 404) on missing X-Deployment-Token header for file upload', async () => {
+  it('400 on missing X-Deployment-Token header for file upload', async () => {
     const { localFetch } = components
 
     const { entityId, contentBuf, contentHash } = await setupInitedDeployment()
@@ -119,7 +120,7 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
       body: contentBuf as any
     })
 
-    expect([400, 404]).toContain(resp.status)
+    expect(resp.status).toBe(400)
   })
 
   it('400 on token mismatch for file upload', async () => {
@@ -180,7 +181,7 @@ test('partial deployment v2 — failure modes', function ({ components, stubComp
       // X-Deployment-Token intentionally omitted
     })
 
-    expect([400, 404]).toContain(resp.status)
+    expect(resp.status).toBe(400)
   })
 
   it('400 on token mismatch for finalize', async () => {

--- a/test/integration/deploy-v2-failures.spec.ts
+++ b/test/integration/deploy-v2-failures.spec.ts
@@ -1,0 +1,233 @@
+import { test } from '../components'
+import { hashV1 } from '@dcl/hashing'
+import { Authenticator } from '@dcl/crypto'
+import { EntityType } from '@dcl/schemas'
+import { DeploymentBuilder } from 'dcl-catalyst-client'
+import { stringToUtf8Bytes } from 'eth-connect'
+import FormData from 'form-data'
+import { getIdentity, makeid, cleanup } from '../utils'
+
+test('partial deployment v2 — failure modes', function ({ components, stubComponents }) {
+  afterEach(async () => {
+    jest.resetAllMocks()
+    const { storage, database } = components
+    await cleanup(storage, database)
+  })
+
+  /**
+   * Initialises a partial deployment and returns the pieces needed for
+   * subsequent test steps.  The deployment is left in an "init done,
+   * no files uploaded yet" state.
+   */
+  async function setupInitedDeployment() {
+    const { localFetch, worldCreator } = components
+    const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
+
+    const identity = await getIdentity()
+    const worldName = worldCreator.randomWorldName()
+
+    namePermissionChecker.checkPermission
+      .withArgs(identity.authChain.authChain[0].payload, worldName)
+      .resolves(true)
+    nameOwnership.findOwners
+      .withArgs([worldName])
+      .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
+    snsClient.publishMessage.resolves({
+      MessageId: 'mocked-message-id',
+      SequenceNumber: 'mocked-sequence-number',
+      $metadata: {}
+    })
+
+    const contentBytes = stringToUtf8Bytes(makeid(100))
+    const contentBuf = Buffer.from(contentBytes)
+    const contentHash = await hashV1(contentBytes)
+
+    const entityFiles = new Map<string, Uint8Array>()
+    entityFiles.set('abc.txt', contentBytes)
+
+    const { entityId, files } = await DeploymentBuilder.buildEntity({
+      type: EntityType.SCENE as any,
+      pointers: ['0,0'],
+      files: entityFiles,
+      metadata: {
+        main: 'abc.txt',
+        scene: {
+          base: '20,24',
+          parcels: ['20,24']
+        },
+        worldConfiguration: {
+          name: worldName
+        }
+      }
+    })
+
+    const entityFileBytes = files.get(entityId)!
+    const authChain = Authenticator.signPayload(identity.authChain, entityId)
+    const manifest: Record<string, number> = { [contentHash]: contentBuf.length }
+
+    const initForm = new FormData()
+    initForm.append('entityId', entityId)
+    authChain.forEach((link, index) => {
+      initForm.append(`authChain[${index}][payload]`, link.payload)
+      initForm.append(`authChain[${index}][signature]`, link.signature)
+      initForm.append(`authChain[${index}][type]`, link.type)
+    })
+    initForm.append(entityId, Buffer.from(entityFileBytes), {
+      filename: entityId,
+      contentType: 'application/octet-stream'
+    })
+    initForm.append('fileSizesManifest', JSON.stringify(manifest))
+
+    const initResp = await localFetch.fetch('/entities', {
+      method: 'POST',
+      headers: { 'Upload-Incomplete': '?1', ...initForm.getHeaders() },
+      body: initForm.getBuffer() as any
+    })
+    expect(initResp.status).toBe(202)
+
+    const initBody = (await initResp.json()) as { missingFiles: string[]; deploymentToken: string }
+    return { entityId, contentBuf, contentHash, token: initBody.deploymentToken }
+  }
+
+  it('404 (or 400) on file upload to unknown entity', async () => {
+    const { localFetch } = components
+
+    const resp = await localFetch.fetch('/entities/QmUnknownEntity000000000000000000000000000000001/files/QmUnknownFile0000000000000000000000000000000001', {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': 'some-token',
+        'Content-Type': 'application/octet-stream'
+      },
+      body: Buffer.from('x') as any
+    })
+
+    expect([400, 404]).toContain(resp.status)
+  })
+
+  it('400 (or 404) on missing X-Deployment-Token header for file upload', async () => {
+    const { localFetch } = components
+
+    const { entityId, contentBuf, contentHash } = await setupInitedDeployment()
+
+    const resp = await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream'
+        // X-Deployment-Token intentionally omitted
+      },
+      body: contentBuf as any
+    })
+
+    expect([400, 404]).toContain(resp.status)
+  })
+
+  it('400 on token mismatch for file upload', async () => {
+    const { localFetch } = components
+
+    const { entityId, contentBuf, contentHash } = await setupInitedDeployment()
+
+    const resp = await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': 'wrong-token-value',
+        'Content-Type': 'application/octet-stream'
+      },
+      body: contentBuf as any
+    })
+
+    expect(resp.status).toBe(400)
+  })
+
+  it('400 on hash mismatch (declared hash does not match actual content)', async () => {
+    const { localFetch } = components
+
+    const { entityId, token, contentHash } = await setupInitedDeployment()
+
+    // Upload bytes whose hash does NOT match contentHash
+    const wrongBytes = Buffer.from(makeid(100))
+
+    const resp = await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': token,
+        'Content-Type': 'application/octet-stream'
+      },
+      body: wrongBytes as any
+    })
+
+    expect(resp.status).toBe(400)
+  })
+
+  it('400 on missing X-Deployment-Token header for finalize', async () => {
+    const { localFetch } = components
+
+    const { entityId, contentBuf, contentHash, token } = await setupInitedDeployment()
+
+    // Upload the file correctly first
+    await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': token,
+        'Content-Type': 'application/octet-stream'
+      },
+      body: contentBuf as any
+    })
+
+    // Finalize without X-Deployment-Token
+    const resp = await localFetch.fetch(`/entities/${entityId}`, {
+      method: 'POST'
+      // X-Deployment-Token intentionally omitted
+    })
+
+    expect([400, 404]).toContain(resp.status)
+  })
+
+  it('400 on token mismatch for finalize', async () => {
+    const { localFetch } = components
+
+    const { entityId, contentBuf, contentHash, token } = await setupInitedDeployment()
+
+    // Upload the file correctly first
+    await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': token,
+        'Content-Type': 'application/octet-stream'
+      },
+      body: contentBuf as any
+    })
+
+    // Finalize with wrong token
+    const resp = await localFetch.fetch(`/entities/${entityId}`, {
+      method: 'POST',
+      headers: {
+        'X-Deployment-Token': 'definitely-the-wrong-token'
+      }
+    })
+
+    expect(resp.status).toBe(400)
+  })
+
+  it('GET /entities/:entityId/status returns 200 with missing files for an active deployment', async () => {
+    const { localFetch } = components
+
+    const { entityId, contentHash } = await setupInitedDeployment()
+
+    // No files uploaded yet — contentHash should still be in missingFiles
+    const statusResp = await localFetch.fetch(`/entities/${entityId}/status`)
+    expect(statusResp.status).toBe(200)
+
+    const statusBody = await statusResp.json()
+    expect(statusBody.missingFiles).toContain(contentHash)
+    expect(statusBody.expiresAt).toBeGreaterThan(Date.now())
+  })
+
+  it('GET /entities/:entityId/status returns 404 for an unknown entity', async () => {
+    const { localFetch } = components
+
+    const statusResp = await localFetch.fetch(
+      '/entities/QmUnknownEntity000000000000000000000000000000001/status'
+    )
+    expect(statusResp.status).toBe(404)
+  })
+})

--- a/test/integration/deploy-v2.spec.ts
+++ b/test/integration/deploy-v2.spec.ts
@@ -1,0 +1,287 @@
+import { test } from '../components'
+import { hashV1 } from '@dcl/hashing'
+import { Authenticator } from '@dcl/crypto'
+import { EntityType } from '@dcl/schemas'
+import { DeploymentBuilder } from 'dcl-catalyst-client'
+import { stringToUtf8Bytes } from 'eth-connect'
+import FormData from 'form-data'
+import { getIdentity, makeid, cleanup } from '../utils'
+
+test('partial deployment v2 — happy path', function ({ components, stubComponents }) {
+  afterEach(async () => {
+    jest.resetAllMocks()
+    const { storage, database } = components
+    await cleanup(storage, database)
+  })
+
+  describe('when the user owns the world name', () => {
+    let worldName: string
+
+    beforeEach(async () => {
+      const { worldCreator } = components
+      const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
+
+      worldName = worldCreator.randomWorldName()
+
+      const identity = await getIdentity()
+      namePermissionChecker.checkPermission
+        .withArgs(identity.authChain.authChain[0].payload, worldName)
+        .resolves(true)
+      nameOwnership.findOwners
+        .withArgs([worldName])
+        .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
+      snsClient.publishMessage.resolves({
+        MessageId: 'mocked-message-id',
+        SequenceNumber: 'mocked-sequence-number',
+        $metadata: {}
+      })
+    })
+
+    it('completes init -> file upload -> finalize', async () => {
+      const { localFetch } = components
+      const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
+
+      const identity = await getIdentity()
+
+      // Override stubs to match the specific identity we use in this test
+      namePermissionChecker.checkPermission
+        .withArgs(identity.authChain.authChain[0].payload, worldName)
+        .resolves(true)
+      nameOwnership.findOwners
+        .withArgs([worldName])
+        .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
+      snsClient.publishMessage.resolves({
+        MessageId: 'mocked-message-id',
+        SequenceNumber: 'mocked-sequence-number',
+        $metadata: {}
+      })
+
+      // Build an entity with a content file
+      const contentBytes = stringToUtf8Bytes(makeid(100))
+      const contentBuf = Buffer.from(contentBytes)
+      const contentHash = await hashV1(contentBytes)
+
+      const entityFiles = new Map<string, Uint8Array>()
+      entityFiles.set('abc.txt', contentBytes)
+
+      const { entityId, files } = await DeploymentBuilder.buildEntity({
+        type: EntityType.SCENE as any,
+        pointers: ['0,0'],
+        files: entityFiles,
+        metadata: {
+          main: 'abc.txt',
+          scene: {
+            base: '20,24',
+            parcels: ['20,24']
+          },
+          worldConfiguration: {
+            name: worldName
+          }
+        }
+      })
+
+      const entityFileBytes = files.get(entityId)!
+
+      // Build auth chain signed over the entityId
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+
+      // Build manifest: map of fileHash -> byte length for non-entity content files
+      const manifest: Record<string, number> = {}
+      manifest[contentHash] = contentBuf.length
+
+      // Step 1: Init — POST /entities with Upload-Incomplete: ?1
+      const initForm = new FormData()
+      initForm.append('entityId', entityId)
+
+      // Append auth chain fields as authChain[i][payload], authChain[i][signature], authChain[i][type]
+      authChain.forEach((link, index) => {
+        initForm.append(`authChain[${index}][payload]`, link.payload)
+        initForm.append(`authChain[${index}][signature]`, link.signature)
+        initForm.append(`authChain[${index}][type]`, link.type)
+      })
+
+      // Append the entity file under its own hash as the filename
+      initForm.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+
+      // Append the fileSizesManifest (covers only non-entity content files)
+      initForm.append('fileSizesManifest', JSON.stringify(manifest))
+
+      const initResp = await localFetch.fetch('/entities', {
+        method: 'POST',
+        headers: { 'Upload-Incomplete': '?1', ...initForm.getHeaders() },
+        body: initForm.getBuffer() as any
+      })
+      expect(initResp.status).toBe(202)
+
+      const initBody = (await initResp.json()) as { missingFiles: string[]; deploymentToken: string }
+      expect(initBody.deploymentToken).toBeTruthy()
+      expect(initBody.missingFiles).toContain(contentHash)
+
+      // Step 2: Upload the missing content file — POST /entities/:entityId/files/:fileHash
+      const uploadResp = await localFetch.fetch(`/entities/${entityId}/files/${contentHash}`, {
+        method: 'POST',
+        headers: {
+          'X-Deployment-Token': initBody.deploymentToken,
+          'Content-Type': 'application/octet-stream'
+        },
+        body: contentBuf as any
+      })
+      expect(uploadResp.status).toBe(204)
+
+      // Step 3: Finalize — POST /entities/:entityId
+      const finalResp = await localFetch.fetch(`/entities/${entityId}`, {
+        method: 'POST',
+        headers: {
+          'X-Deployment-Token': initBody.deploymentToken
+        }
+      })
+      expect(finalResp.status).toBe(200)
+      const finalBody = await finalResp.json()
+      expect(finalBody).toMatchObject({ creationTimestamp: expect.any(Number) })
+    })
+
+    it('returns available files on re-init for the same entity and owner', async () => {
+      const { localFetch } = components
+      const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
+
+      const identity = await getIdentity()
+
+      namePermissionChecker.checkPermission
+        .withArgs(identity.authChain.authChain[0].payload, worldName)
+        .resolves(true)
+      nameOwnership.findOwners
+        .withArgs([worldName])
+        .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
+      snsClient.publishMessage.resolves({
+        MessageId: 'mocked-message-id',
+        SequenceNumber: 'mocked-sequence-number',
+        $metadata: {}
+      })
+
+      const contentBytes = stringToUtf8Bytes(makeid(100))
+      const contentHash = await hashV1(contentBytes)
+
+      const entityFiles = new Map<string, Uint8Array>()
+      entityFiles.set('abc.txt', contentBytes)
+
+      const { entityId, files } = await DeploymentBuilder.buildEntity({
+        type: EntityType.SCENE as any,
+        pointers: ['0,0'],
+        files: entityFiles,
+        metadata: {
+          main: 'abc.txt',
+          scene: {
+            base: '20,24',
+            parcels: ['20,24']
+          },
+          worldConfiguration: {
+            name: worldName
+          }
+        }
+      })
+
+      const entityFileBytes = files.get(entityId)!
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const manifest: Record<string, number> = { [contentHash]: contentBytes.length }
+
+      const buildInitForm = () => {
+        const form = new FormData()
+        form.append('entityId', entityId)
+        authChain.forEach((link, index) => {
+          form.append(`authChain[${index}][payload]`, link.payload)
+          form.append(`authChain[${index}][signature]`, link.signature)
+          form.append(`authChain[${index}][type]`, link.type)
+        })
+        form.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+        form.append('fileSizesManifest', JSON.stringify(manifest))
+        return form
+      }
+
+      // First init
+      const firstForm = buildInitForm()
+      const firstResp = await localFetch.fetch('/entities', {
+        method: 'POST',
+        headers: { 'Upload-Incomplete': '?1', ...firstForm.getHeaders() },
+        body: firstForm.getBuffer() as any
+      })
+      expect(firstResp.status).toBe(202)
+      const firstBody = (await firstResp.json()) as { deploymentToken: string }
+
+      // Second init (same entity, same owner) — should return the same token
+      const secondForm = buildInitForm()
+      const secondResp = await localFetch.fetch('/entities', {
+        method: 'POST',
+        headers: { 'Upload-Incomplete': '?1', ...secondForm.getHeaders() },
+        body: secondForm.getBuffer() as any
+      })
+      expect(secondResp.status).toBe(202)
+      const secondBody = (await secondResp.json()) as { deploymentToken: string }
+
+      expect(secondBody.deploymentToken).toBe(firstBody.deploymentToken)
+    })
+
+    it('GET /entities/:entityId/status returns the deployment status with missing files', async () => {
+      const { localFetch } = components
+      const { namePermissionChecker, nameOwnership } = stubComponents
+
+      const identity = await getIdentity()
+
+      namePermissionChecker.checkPermission
+        .withArgs(identity.authChain.authChain[0].payload, worldName)
+        .resolves(true)
+      nameOwnership.findOwners
+        .withArgs([worldName])
+        .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
+
+      const contentBytes = stringToUtf8Bytes(makeid(100))
+      const contentHash = await hashV1(contentBytes)
+
+      const entityFiles = new Map<string, Uint8Array>()
+      entityFiles.set('abc.txt', contentBytes)
+
+      const { entityId, files } = await DeploymentBuilder.buildEntity({
+        type: EntityType.SCENE as any,
+        pointers: ['0,0'],
+        files: entityFiles,
+        metadata: {
+          main: 'abc.txt',
+          scene: {
+            base: '20,24',
+            parcels: ['20,24']
+          },
+          worldConfiguration: {
+            name: worldName
+          }
+        }
+      })
+
+      const entityFileBytes = files.get(entityId)!
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const manifest: Record<string, number> = { [contentHash]: contentBytes.length }
+
+      const initForm = new FormData()
+      initForm.append('entityId', entityId)
+      authChain.forEach((link, index) => {
+        initForm.append(`authChain[${index}][payload]`, link.payload)
+        initForm.append(`authChain[${index}][signature]`, link.signature)
+        initForm.append(`authChain[${index}][type]`, link.type)
+      })
+      initForm.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+      initForm.append('fileSizesManifest', JSON.stringify(manifest))
+
+      const initResp = await localFetch.fetch('/entities', {
+        method: 'POST',
+        headers: { 'Upload-Incomplete': '?1', ...initForm.getHeaders() },
+        body: initForm.getBuffer() as any
+      })
+      expect(initResp.status).toBe(202)
+
+      // Status should show missing files before upload
+      const statusResp = await localFetch.fetch(`/entities/${entityId}/status`)
+      expect(statusResp.status).toBe(200)
+      const statusBody = await statusResp.json()
+      expect(statusBody.missingFiles).toContain(contentHash)
+      expect(statusBody.expiresAt).toBeGreaterThan(Date.now())
+    })
+  })
+})

--- a/test/integration/deploy-v2.spec.ts
+++ b/test/integration/deploy-v2.spec.ts
@@ -24,9 +24,7 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
       worldName = worldCreator.randomWorldName()
 
       const identity = await getIdentity()
-      namePermissionChecker.checkPermission
-        .withArgs(identity.authChain.authChain[0].payload, worldName)
-        .resolves(true)
+      namePermissionChecker.checkPermission.withArgs(identity.authChain.authChain[0].payload, worldName).resolves(true)
       nameOwnership.findOwners
         .withArgs([worldName])
         .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
@@ -44,9 +42,7 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
       const identity = await getIdentity()
 
       // Override stubs to match the specific identity we use in this test
-      namePermissionChecker.checkPermission
-        .withArgs(identity.authChain.authChain[0].payload, worldName)
-        .resolves(true)
+      namePermissionChecker.checkPermission.withArgs(identity.authChain.authChain[0].payload, worldName).resolves(true)
       nameOwnership.findOwners
         .withArgs([worldName])
         .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
@@ -101,7 +97,10 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
       })
 
       // Append the entity file under its own hash as the filename
-      initForm.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+      initForm.append(entityId, Buffer.from(entityFileBytes), {
+        filename: entityId,
+        contentType: 'application/octet-stream'
+      })
 
       // Append the fileSizesManifest (covers only non-entity content files)
       initForm.append('fileSizesManifest', JSON.stringify(manifest))
@@ -146,9 +145,7 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
 
       const identity = await getIdentity()
 
-      namePermissionChecker.checkPermission
-        .withArgs(identity.authChain.authChain[0].payload, worldName)
-        .resolves(true)
+      namePermissionChecker.checkPermission.withArgs(identity.authChain.authChain[0].payload, worldName).resolves(true)
       nameOwnership.findOwners
         .withArgs([worldName])
         .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
@@ -192,7 +189,10 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
           form.append(`authChain[${index}][signature]`, link.signature)
           form.append(`authChain[${index}][type]`, link.type)
         })
-        form.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+        form.append(entityId, Buffer.from(entityFileBytes), {
+          filename: entityId,
+          contentType: 'application/octet-stream'
+        })
         form.append('fileSizesManifest', JSON.stringify(manifest))
         return form
       }
@@ -226,9 +226,7 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
 
       const identity = await getIdentity()
 
-      namePermissionChecker.checkPermission
-        .withArgs(identity.authChain.authChain[0].payload, worldName)
-        .resolves(true)
+      namePermissionChecker.checkPermission.withArgs(identity.authChain.authChain[0].payload, worldName).resolves(true)
       nameOwnership.findOwners
         .withArgs([worldName])
         .resolves(new Map([[worldName, identity.authChain.authChain[0].payload]]))
@@ -266,7 +264,10 @@ test('partial deployment v2 — happy path', function ({ components, stubCompone
         initForm.append(`authChain[${index}][signature]`, link.signature)
         initForm.append(`authChain[${index}][type]`, link.type)
       })
-      initForm.append(entityId, Buffer.from(entityFileBytes), { filename: entityId, contentType: 'application/octet-stream' })
+      initForm.append(entityId, Buffer.from(entityFileBytes), {
+        filename: entityId,
+        contentType: 'application/octet-stream'
+      })
       initForm.append('fileSizesManifest', JSON.stringify(manifest))
 
       const initResp = await localFetch.fetch('/entities', {

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -319,3 +319,45 @@ describe('partialDeploymentManager.complete', () => {
     await expect(tempStorage.getFile('QmE', fileHash)).rejects.toThrow()
   })
 })
+
+describe('partialDeploymentManager.status', () => {
+  it('returns undefined for unknown entity', async () => {
+    const { manager } = makeManager()
+    expect(await manager.status('QmNope')).toBeUndefined()
+  })
+
+  it('returns availableFiles, missingFiles, expiresAt for known deployment', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const fileHash = await hashV1(bytes)
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [fileHash]: 3, QmOther: 5 }
+    })
+    await manager.addFile('QmE', fileHash, init.deploymentToken, bytes)
+
+    const s = await manager.status('QmE')
+    expect(s!.availableFiles.sort()).toEqual([fileHash])
+    expect(s!.missingFiles).toEqual(['QmOther'])
+    expect(s!.expiresAt).toBe(init.expiresAt)
+  })
+
+  it('returns undefined and cleans up if expired', async () => {
+    const { manager, store } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: {}
+    })
+    expect(init.deploymentToken).toBeTruthy()
+    const r = await store.get('QmE')
+    r!.expiresAt = Date.now() - 1
+    expect(await manager.status('QmE')).toBeUndefined()
+    expect(await store.get('QmE')).toBeUndefined() // lazy eviction triggered
+  })
+})

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -1,0 +1,120 @@
+import { createInMemoryStorage } from '@dcl/catalyst-storage'
+import { createPartialDeploymentStore } from '../../src/adapters/partial-deployment-store'
+import { createPartialDeploymentTempStorage } from '../../src/adapters/partial-deployment-temp-storage'
+import { createMutex } from '../../src/adapters/partial-deployment-mutex'
+import { createPartialDeploymentManager } from '../../src/adapters/partial-deployment-manager'
+import { IPartialDeploymentValidator } from '../../src/types'
+import { bufferToStream } from '@dcl/catalyst-storage'
+
+const okValidator: IPartialDeploymentValidator = {
+  preflight: async () => ({ ok: () => true, errors: [] }),
+  final: async () => ({ ok: () => true, errors: [] })
+}
+
+const baseLogger: any = {
+  log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {}
+}
+
+function makeManager(opts: { validator?: IPartialDeploymentValidator } = {}) {
+  const storage = createInMemoryStorage()
+  const store = createPartialDeploymentStore()
+  const tempStorage = createPartialDeploymentTempStorage({ storage })
+  const mutex = createMutex()
+  const manager = createPartialDeploymentManager({
+    storage,
+    partialDeploymentStore: store,
+    partialDeploymentTempStorage: tempStorage,
+    partialDeploymentValidator: opts.validator ?? okValidator,
+    entityDeployer: { deployEntity: jest.fn().mockResolvedValue({ message: 'ok' }) } as any,
+    logs: { getLogger: () => baseLogger } as any
+  } as any, mutex)
+  return { manager, store, storage, tempStorage }
+}
+
+describe('partialDeploymentManager.init', () => {
+  it('returns a deployment token, expiresAt, and missingFiles', async () => {
+    const { manager } = makeManager()
+    const result = await manager.init({
+      entityId: 'QmEntity',
+      entityRaw: Buffer.from('{"content":[]}'),
+      authChain: [{ type: 'SIGNER' as any, payload: '0xabc', signature: '' }],
+      ownerAddress: '0xabc',
+      manifest: { QmA: 10, QmB: 20 }
+    })
+
+    expect(result.deploymentToken).toMatch(/^[a-f0-9]{64}$/)
+    expect(result.expiresAt).toBeGreaterThan(Date.now())
+    expect(result.missingFiles.sort()).toEqual(['QmA', 'QmB'])
+    expect(result.availableFiles).toEqual([])
+  })
+
+  it('marks already-stored hashes as available', async () => {
+    const { manager, storage } = makeManager()
+    await storage.storeStream('QmA', bufferToStream(Buffer.from('a')))
+    const result = await manager.init({
+      entityId: 'QmEntity',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { QmA: 1, QmB: 2 }
+    })
+    expect(result.availableFiles).toEqual(['QmA'])
+    expect(result.missingFiles).toEqual(['QmB'])
+  })
+
+  it('idempotent re-init for the same wallet returns the same token', async () => {
+    const { manager } = makeManager()
+    const r1 = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { QmA: 1 }
+    })
+    const r2 = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { QmA: 1 }
+    })
+    expect(r2.deploymentToken).toBe(r1.deploymentToken)
+  })
+
+  it('rejects re-init from a different wallet', async () => {
+    const { manager } = makeManager()
+    await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xaaa',
+      manifest: { QmA: 1 }
+    })
+    await expect(
+      manager.init({
+        entityId: 'QmE',
+        entityRaw: Buffer.from('{}'),
+        authChain: [],
+        ownerAddress: '0xbbb',
+        manifest: { QmA: 1 }
+      })
+    ).rejects.toThrow(/owner mismatch/i)
+  })
+
+  it('throws if validator.preflight rejects', async () => {
+    const validator = {
+      preflight: async () => ({ ok: () => false, errors: ['nope'] }),
+      final: async () => ({ ok: () => true, errors: [] })
+    }
+    const { manager } = makeManager({ validator })
+    await expect(
+      manager.init({
+        entityId: 'QmE',
+        entityRaw: Buffer.from('{}'),
+        authChain: [],
+        ownerAddress: '0xabc',
+        manifest: {}
+      })
+    ).rejects.toThrow(/nope/)
+  })
+})

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -6,6 +6,7 @@ import { createMutex } from '../../src/adapters/partial-deployment-mutex'
 import { createPartialDeploymentManager } from '../../src/adapters/partial-deployment-manager'
 import { IPartialDeploymentValidator } from '../../src/types'
 import { bufferToStream } from '@dcl/catalyst-storage'
+import { NotFoundError } from '@dcl/http-commons'
 
 const okValidator: IPartialDeploymentValidator = {
   preflight: async () => ({ ok: () => true, errors: [] }),
@@ -125,6 +126,24 @@ describe('partialDeploymentManager.init', () => {
       })
     ).rejects.toThrow(/nope/)
   })
+
+  it('passes entityRaw to validator.preflight', async () => {
+    const preflightSpy = jest.fn().mockResolvedValue({ ok: () => true, errors: [] })
+    const validator: IPartialDeploymentValidator = {
+      preflight: preflightSpy,
+      final: async () => ({ ok: () => true, errors: [] })
+    }
+    const entityRaw = Buffer.from('{"content":[]}')
+    const { manager } = makeManager({ validator })
+    await manager.init({
+      entityId: 'QmE',
+      entityRaw,
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: {}
+    })
+    expect(preflightSpy).toHaveBeenCalledWith(expect.objectContaining({ entityRaw }))
+  })
 })
 
 describe('partialDeploymentManager.addFile', () => {
@@ -133,6 +152,7 @@ describe('partialDeploymentManager.addFile', () => {
     await expect(manager.addFile('QmNope', 'QmA', 'tok', Buffer.from('a'))).rejects.toMatchObject({
       message: expect.stringMatching(/not found/i)
     })
+    await expect(manager.addFile('QmNope', 'QmA', 'tok', Buffer.from('a'))).rejects.toBeInstanceOf(NotFoundError)
   })
 
   it('rejects when token mismatches', async () => {
@@ -211,6 +231,7 @@ describe('partialDeploymentManager.addFile', () => {
     const r = await store.get('QmE')
     r!.expiresAt = Date.now() - 1
     await expect(manager.addFile('QmE', realHash, init.deploymentToken, bytes)).rejects.toThrow(/expired/i)
+    await expect(manager.addFile('QmE', realHash, init.deploymentToken, bytes)).rejects.toBeInstanceOf(NotFoundError)
   })
 
   it('happy path: stores file, marks uploaded', async () => {
@@ -237,6 +258,7 @@ describe('partialDeploymentManager.complete', () => {
   it('rejects unknown deployment', async () => {
     const { manager } = makeManager()
     await expect(manager.complete('http://baseUrl', 'QmNope', 'tok')).rejects.toThrow(/not found/i)
+    await expect(manager.complete('http://baseUrl', 'QmNope', 'tok')).rejects.toBeInstanceOf(NotFoundError)
   })
 
   it('rejects token mismatch', async () => {
@@ -252,7 +274,7 @@ describe('partialDeploymentManager.complete', () => {
     await expect(manager.complete('http://x', 'QmE', 'wrong')).rejects.toThrow(/token/i)
   })
 
-  it('rejects expired deployment', async () => {
+  it('rejects expired deployment with NotFoundError (mapped to 404)', async () => {
     const { manager, store } = makeManager()
     const init = await manager.init({
       entityId: 'QmE',
@@ -263,7 +285,9 @@ describe('partialDeploymentManager.complete', () => {
     })
     const r = await store.get('QmE')
     r!.expiresAt = Date.now() - 1
-    await expect(manager.complete('http://x', 'QmE', init.deploymentToken)).rejects.toThrow(/expired/i)
+    const err = await manager.complete('http://x', 'QmE', init.deploymentToken).catch((e) => e)
+    expect(err).toBeInstanceOf(NotFoundError)
+    expect(err.message).toMatch(/expired/i)
   })
 
   it('rejects when validator.final fails', async () => {
@@ -319,6 +343,66 @@ describe('partialDeploymentManager.complete', () => {
     expect(await store.get('QmE')).toBeUndefined()
     await expect(tempStorage.getEntityRaw('QmE')).rejects.toThrow()
     await expect(tempStorage.getFile('QmE', fileHash)).rejects.toThrow()
+  })
+
+  it('passes entity raw into validator.final via files map keyed by entity.id', async () => {
+    const finalSpy = jest.fn().mockResolvedValue({ ok: () => true, errors: [] })
+    const validator: IPartialDeploymentValidator = {
+      preflight: async () => ({ ok: () => true, errors: [] }),
+      final: finalSpy
+    }
+    const bytes = Buffer.from([1, 2, 3])
+    const fileHash = await hashV1(bytes)
+    const entityRaw = Buffer.from(JSON.stringify({ content: [{ file: 'a.glb', hash: fileHash }] }))
+    const { manager } = makeManager({ validator })
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw,
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [fileHash]: 3 }
+    })
+    await manager.addFile('QmE', fileHash, init.deploymentToken, bytes)
+    await manager.complete('http://x', 'QmE', init.deploymentToken)
+
+    expect(finalSpy).toHaveBeenCalled()
+    const passedDeployment = finalSpy.mock.calls[0][0]
+    expect(passedDeployment.files.get('QmE')).toBeDefined()
+    expect(Buffer.from(passedDeployment.files.get('QmE')).toString()).toBe(entityRaw.toString())
+  })
+
+  it('preserves the record when deployEntity throws transiently', async () => {
+    const deployFn = jest.fn().mockRejectedValue(new Error('SNS down'))
+    const storage = createInMemoryStorage()
+    const store = createPartialDeploymentStore()
+    const tempStorage = createPartialDeploymentTempStorage({ storage })
+    const mutex = createMutex()
+    const manager = createPartialDeploymentManager(
+      {
+        storage,
+        partialDeploymentStore: store,
+        partialDeploymentTempStorage: tempStorage,
+        partialDeploymentValidator: okValidator,
+        entityDeployer: { deployEntity: deployFn } as any,
+        logs: { getLogger: () => baseLogger } as any
+      } as any,
+      mutex
+    )
+
+    const bytes = Buffer.from([1, 2, 3])
+    const fileHash = await hashV1(bytes)
+    const entityRaw = Buffer.from(JSON.stringify({ content: [{ file: 'a.glb', hash: fileHash }] }))
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw,
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [fileHash]: 3 }
+    })
+    await manager.addFile('QmE', fileHash, init.deploymentToken, bytes)
+    await expect(manager.complete('http://x', 'QmE', init.deploymentToken)).rejects.toThrow('SNS down')
+    // Record is preserved so the client can retry without re-initialising.
+    expect(await store.get('QmE')).toBeDefined()
   })
 })
 

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -1,3 +1,4 @@
+import { hashV1 } from '@dcl/hashing'
 import { createInMemoryStorage } from '@dcl/catalyst-storage'
 import { createPartialDeploymentStore } from '../../src/adapters/partial-deployment-store'
 import { createPartialDeploymentTempStorage } from '../../src/adapters/partial-deployment-temp-storage'
@@ -116,5 +117,119 @@ describe('partialDeploymentManager.init', () => {
         manifest: {}
       })
     ).rejects.toThrow(/nope/)
+  })
+})
+
+describe('partialDeploymentManager.addFile', () => {
+  it('rejects unknown deployment with not-found error', async () => {
+    const { manager } = makeManager()
+    await expect(
+      manager.addFile('QmNope', 'QmA', 'tok', Buffer.from('a'))
+    ).rejects.toMatchObject({ message: expect.stringMatching(/not found/i) })
+  })
+
+  it('rejects when token mismatches', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const fileHash = await hashV1(bytes)
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [fileHash]: 3 }
+    })
+    expect(init.missingFiles).toContain(fileHash)
+    await expect(
+      manager.addFile('QmE', fileHash, 'wrong-token', bytes)
+    ).rejects.toThrow(/token/i)
+  })
+
+  it('rejects when computed hash does not match path hash (FIXES Mariano inverted-check bug)', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const realHash = await hashV1(bytes)
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [realHash]: 3 }
+    })
+
+    await expect(
+      manager.addFile('QmE', 'QmFakeHash', init.deploymentToken, bytes)
+    ).rejects.toThrow(/hash mismatch/i)
+  })
+
+  it('rejects when fileHash is not in the declared manifest', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const realHash = await hashV1(bytes)
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { 'QmSomeOtherHash': 99 }
+    })
+    expect(init.missingFiles).toContain('QmSomeOtherHash')
+    await expect(
+      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
+    ).rejects.toThrow(/not in manifest|unexpected/i)
+  })
+
+  it('rejects when bytes.length disagrees with manifest size', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const realHash = await hashV1(bytes)
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [realHash]: 99 }
+    })
+    expect(init.missingFiles).toContain(realHash)
+    await expect(
+      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
+    ).rejects.toThrow(/size/i)
+  })
+
+  it('rejects when expiresAt has passed (lazy eviction)', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const realHash = await hashV1(bytes)
+    const { manager, store } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [realHash]: 3 }
+    })
+    const r = await store.get('QmE')
+    r!.expiresAt = Date.now() - 1
+    await expect(
+      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
+    ).rejects.toThrow(/expired/i)
+  })
+
+  it('happy path: stores file, marks uploaded', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const realHash = await hashV1(bytes)
+    const { manager, store, tempStorage } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: { [realHash]: 3 }
+    })
+    await manager.addFile('QmE', realHash, init.deploymentToken, bytes)
+
+    const r = await store.get('QmE')
+    expect(r!.uploadedHashes.has(realHash)).toBe(true)
+    const stored = await tempStorage.getFile('QmE', realHash)
+    expect([...stored]).toEqual([1, 2, 3])
   })
 })

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -13,7 +13,11 @@ const okValidator: IPartialDeploymentValidator = {
 }
 
 const baseLogger: any = {
-  log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {}
+  log: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {}
 }
 
 function makeManager(opts: { validator?: IPartialDeploymentValidator } = {}) {
@@ -21,14 +25,17 @@ function makeManager(opts: { validator?: IPartialDeploymentValidator } = {}) {
   const store = createPartialDeploymentStore()
   const tempStorage = createPartialDeploymentTempStorage({ storage })
   const mutex = createMutex()
-  const manager = createPartialDeploymentManager({
-    storage,
-    partialDeploymentStore: store,
-    partialDeploymentTempStorage: tempStorage,
-    partialDeploymentValidator: opts.validator ?? okValidator,
-    entityDeployer: { deployEntity: jest.fn().mockResolvedValue({ message: 'ok' }) } as any,
-    logs: { getLogger: () => baseLogger } as any
-  } as any, mutex)
+  const manager = createPartialDeploymentManager(
+    {
+      storage,
+      partialDeploymentStore: store,
+      partialDeploymentTempStorage: tempStorage,
+      partialDeploymentValidator: opts.validator ?? okValidator,
+      entityDeployer: { deployEntity: jest.fn().mockResolvedValue({ message: 'ok' }) } as any,
+      logs: { getLogger: () => baseLogger } as any
+    } as any,
+    mutex
+  )
   return { manager, store, storage, tempStorage }
 }
 
@@ -123,9 +130,9 @@ describe('partialDeploymentManager.init', () => {
 describe('partialDeploymentManager.addFile', () => {
   it('rejects unknown deployment with not-found error', async () => {
     const { manager } = makeManager()
-    await expect(
-      manager.addFile('QmNope', 'QmA', 'tok', Buffer.from('a'))
-    ).rejects.toMatchObject({ message: expect.stringMatching(/not found/i) })
+    await expect(manager.addFile('QmNope', 'QmA', 'tok', Buffer.from('a'))).rejects.toMatchObject({
+      message: expect.stringMatching(/not found/i)
+    })
   })
 
   it('rejects when token mismatches', async () => {
@@ -140,9 +147,7 @@ describe('partialDeploymentManager.addFile', () => {
       manifest: { [fileHash]: 3 }
     })
     expect(init.missingFiles).toContain(fileHash)
-    await expect(
-      manager.addFile('QmE', fileHash, 'wrong-token', bytes)
-    ).rejects.toThrow(/token/i)
+    await expect(manager.addFile('QmE', fileHash, 'wrong-token', bytes)).rejects.toThrow(/token/i)
   })
 
   it('rejects when computed hash does not match path hash (FIXES Mariano inverted-check bug)', async () => {
@@ -157,9 +162,7 @@ describe('partialDeploymentManager.addFile', () => {
       manifest: { [realHash]: 3 }
     })
 
-    await expect(
-      manager.addFile('QmE', 'QmFakeHash', init.deploymentToken, bytes)
-    ).rejects.toThrow(/hash mismatch/i)
+    await expect(manager.addFile('QmE', 'QmFakeHash', init.deploymentToken, bytes)).rejects.toThrow(/hash mismatch/i)
   })
 
   it('rejects when fileHash is not in the declared manifest', async () => {
@@ -171,12 +174,12 @@ describe('partialDeploymentManager.addFile', () => {
       entityRaw: Buffer.from('{}'),
       authChain: [],
       ownerAddress: '0xabc',
-      manifest: { 'QmSomeOtherHash': 99 }
+      manifest: { QmSomeOtherHash: 99 }
     })
     expect(init.missingFiles).toContain('QmSomeOtherHash')
-    await expect(
-      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
-    ).rejects.toThrow(/not in manifest|unexpected/i)
+    await expect(manager.addFile('QmE', realHash, init.deploymentToken, bytes)).rejects.toThrow(
+      /not in manifest|unexpected/i
+    )
   })
 
   it('rejects when bytes.length disagrees with manifest size', async () => {
@@ -191,9 +194,7 @@ describe('partialDeploymentManager.addFile', () => {
       manifest: { [realHash]: 99 }
     })
     expect(init.missingFiles).toContain(realHash)
-    await expect(
-      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
-    ).rejects.toThrow(/size/i)
+    await expect(manager.addFile('QmE', realHash, init.deploymentToken, bytes)).rejects.toThrow(/size/i)
   })
 
   it('rejects when expiresAt has passed (lazy eviction)', async () => {
@@ -209,9 +210,7 @@ describe('partialDeploymentManager.addFile', () => {
     })
     const r = await store.get('QmE')
     r!.expiresAt = Date.now() - 1
-    await expect(
-      manager.addFile('QmE', realHash, init.deploymentToken, bytes)
-    ).rejects.toThrow(/expired/i)
+    await expect(manager.addFile('QmE', realHash, init.deploymentToken, bytes)).rejects.toThrow(/expired/i)
   })
 
   it('happy path: stores file, marks uploaded', async () => {
@@ -292,14 +291,17 @@ describe('partialDeploymentManager.complete', () => {
     const store = createPartialDeploymentStore()
     const tempStorage = createPartialDeploymentTempStorage({ storage })
     const mutex = createMutex()
-    const manager = createPartialDeploymentManager({
-      storage,
-      partialDeploymentStore: store,
-      partialDeploymentTempStorage: tempStorage,
-      partialDeploymentValidator: okValidator,
-      entityDeployer: { deployEntity: deployFn } as any,
-      logs: { getLogger: () => baseLogger } as any
-    } as any, mutex)
+    const manager = createPartialDeploymentManager(
+      {
+        storage,
+        partialDeploymentStore: store,
+        partialDeploymentTempStorage: tempStorage,
+        partialDeploymentValidator: okValidator,
+        entityDeployer: { deployEntity: deployFn } as any,
+        logs: { getLogger: () => baseLogger } as any
+      } as any,
+      mutex
+    )
 
     const init = await manager.init({
       entityId: 'QmE',

--- a/test/unit/partial-deployment-manager.spec.ts
+++ b/test/unit/partial-deployment-manager.spec.ts
@@ -233,3 +233,89 @@ describe('partialDeploymentManager.addFile', () => {
     expect([...stored]).toEqual([1, 2, 3])
   })
 })
+
+describe('partialDeploymentManager.complete', () => {
+  it('rejects unknown deployment', async () => {
+    const { manager } = makeManager()
+    await expect(manager.complete('http://baseUrl', 'QmNope', 'tok')).rejects.toThrow(/not found/i)
+  })
+
+  it('rejects token mismatch', async () => {
+    const { manager } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: {}
+    })
+    expect(init.deploymentToken).toBeTruthy()
+    await expect(manager.complete('http://x', 'QmE', 'wrong')).rejects.toThrow(/token/i)
+  })
+
+  it('rejects expired deployment', async () => {
+    const { manager, store } = makeManager()
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: {}
+    })
+    const r = await store.get('QmE')
+    r!.expiresAt = Date.now() - 1
+    await expect(manager.complete('http://x', 'QmE', init.deploymentToken)).rejects.toThrow(/expired/i)
+  })
+
+  it('rejects when validator.final fails', async () => {
+    const validator = {
+      preflight: async () => ({ ok: () => true, errors: [] }),
+      final: async () => ({ ok: () => false, errors: ['boom'] })
+    }
+    const { manager } = makeManager({ validator })
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw: Buffer.from('{"content":[]}'),
+      authChain: [],
+      ownerAddress: '0xabc',
+      manifest: {}
+    })
+    await expect(manager.complete('http://x', 'QmE', init.deploymentToken)).rejects.toThrow(/boom/)
+  })
+
+  it('happy path: validates, deploys, cleans up store + temp', async () => {
+    const bytes = Buffer.from([1, 2, 3])
+    const fileHash = await hashV1(bytes)
+    const entityRaw = Buffer.from(JSON.stringify({ content: [{ file: 'a.glb', hash: fileHash }] }))
+    const deployFn = jest.fn().mockResolvedValue({ message: 'deployed' })
+    const storage = createInMemoryStorage()
+    const store = createPartialDeploymentStore()
+    const tempStorage = createPartialDeploymentTempStorage({ storage })
+    const mutex = createMutex()
+    const manager = createPartialDeploymentManager({
+      storage,
+      partialDeploymentStore: store,
+      partialDeploymentTempStorage: tempStorage,
+      partialDeploymentValidator: okValidator,
+      entityDeployer: { deployEntity: deployFn } as any,
+      logs: { getLogger: () => baseLogger } as any
+    } as any, mutex)
+
+    const init = await manager.init({
+      entityId: 'QmE',
+      entityRaw,
+      authChain: [{ type: 'SIGNER' as any, payload: '0xabc', signature: '' }],
+      ownerAddress: '0xabc',
+      manifest: { [fileHash]: 3 }
+    })
+    await manager.addFile('QmE', fileHash, init.deploymentToken, bytes)
+    const result = await manager.complete('http://baseUrl', 'QmE', init.deploymentToken)
+
+    expect(result).toEqual({ message: 'deployed' })
+    expect(deployFn).toHaveBeenCalled()
+    // Cleanup verified: store + temp emptied
+    expect(await store.get('QmE')).toBeUndefined()
+    await expect(tempStorage.getEntityRaw('QmE')).rejects.toThrow()
+    await expect(tempStorage.getFile('QmE', fileHash)).rejects.toThrow()
+  })
+})

--- a/test/unit/partial-deployment-mutex.spec.ts
+++ b/test/unit/partial-deployment-mutex.spec.ts
@@ -4,8 +4,18 @@ describe('createMutex', () => {
   it('serializes work for the same key', async () => {
     const mutex = createMutex()
     const order: string[] = []
-    const a = mutex.run('k', async () => { order.push('a-start'); await new Promise(r => setTimeout(r, 20)); order.push('a-end'); return 'A' })
-    const b = mutex.run('k', async () => { order.push('b-start'); await new Promise(r => setTimeout(r, 5)); order.push('b-end'); return 'B' })
+    const a = mutex.run('k', async () => {
+      order.push('a-start')
+      await new Promise((r) => setTimeout(r, 20))
+      order.push('a-end')
+      return 'A'
+    })
+    const b = mutex.run('k', async () => {
+      order.push('b-start')
+      await new Promise((r) => setTimeout(r, 5))
+      order.push('b-end')
+      return 'B'
+    })
     const [ra, rb] = await Promise.all([a, b])
     expect(ra).toBe('A')
     expect(rb).toBe('B')
@@ -15,8 +25,16 @@ describe('createMutex', () => {
   it('runs different keys concurrently', async () => {
     const mutex = createMutex()
     const order: string[] = []
-    const a = mutex.run('x', async () => { order.push('a-start'); await new Promise(r => setTimeout(r, 20)); order.push('a-end') })
-    const b = mutex.run('y', async () => { order.push('b-start'); await new Promise(r => setTimeout(r, 5)); order.push('b-end') })
+    const a = mutex.run('x', async () => {
+      order.push('a-start')
+      await new Promise((r) => setTimeout(r, 20))
+      order.push('a-end')
+    })
+    const b = mutex.run('y', async () => {
+      order.push('b-start')
+      await new Promise((r) => setTimeout(r, 5))
+      order.push('b-end')
+    })
     await Promise.all([a, b])
     // b finishes before a-end because they run on different keys
     expect(order).toEqual(['a-start', 'b-start', 'b-end', 'a-end'])
@@ -24,7 +42,11 @@ describe('createMutex', () => {
 
   it('frees the slot after a thrown error', async () => {
     const mutex = createMutex()
-    await expect(mutex.run('k', async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    await expect(
+      mutex.run('k', async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
     // After the error, a new run should start immediately (not hang)
     const r = await mutex.run('k', async () => 42)
     expect(r).toBe(42)

--- a/test/unit/partial-deployment-mutex.spec.ts
+++ b/test/unit/partial-deployment-mutex.spec.ts
@@ -1,0 +1,32 @@
+import { createMutex } from '../../src/adapters/partial-deployment-mutex'
+
+describe('createMutex', () => {
+  it('serializes work for the same key', async () => {
+    const mutex = createMutex()
+    const order: string[] = []
+    const a = mutex.run('k', async () => { order.push('a-start'); await new Promise(r => setTimeout(r, 20)); order.push('a-end'); return 'A' })
+    const b = mutex.run('k', async () => { order.push('b-start'); await new Promise(r => setTimeout(r, 5)); order.push('b-end'); return 'B' })
+    const [ra, rb] = await Promise.all([a, b])
+    expect(ra).toBe('A')
+    expect(rb).toBe('B')
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end'])
+  })
+
+  it('runs different keys concurrently', async () => {
+    const mutex = createMutex()
+    const order: string[] = []
+    const a = mutex.run('x', async () => { order.push('a-start'); await new Promise(r => setTimeout(r, 20)); order.push('a-end') })
+    const b = mutex.run('y', async () => { order.push('b-start'); await new Promise(r => setTimeout(r, 5)); order.push('b-end') })
+    await Promise.all([a, b])
+    // b finishes before a-end because they run on different keys
+    expect(order).toEqual(['a-start', 'b-start', 'b-end', 'a-end'])
+  })
+
+  it('frees the slot after a thrown error', async () => {
+    const mutex = createMutex()
+    await expect(mutex.run('k', async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    // After the error, a new run should start immediately (not hang)
+    const r = await mutex.run('k', async () => 42)
+    expect(r).toBe(42)
+  })
+})

--- a/test/unit/partial-deployment-store.spec.ts
+++ b/test/unit/partial-deployment-store.spec.ts
@@ -1,0 +1,67 @@
+import { createPartialDeploymentStore } from '../../src/adapters/partial-deployment-store'
+import { DeploymentRecord } from '../../src/types'
+
+function makeRecord(entityId: string, expiresAt: number): DeploymentRecord {
+  return {
+    entityId,
+    authChain: [],
+    ownerAddress: '0xabc',
+    manifest: { QmA: 3 },
+    uploadedHashes: new Set(),
+    alreadyAvailableHashes: new Set(),
+    deploymentToken: 'tok-' + entityId,
+    expiresAt
+  }
+}
+
+describe('createPartialDeploymentStore', () => {
+  it('put/get round-trips the record', async () => {
+    const store = createPartialDeploymentStore()
+    const r = makeRecord('QmEntity', Date.now() + 60_000)
+    await store.put(r)
+    const got = await store.get('QmEntity')
+    expect(got).toBe(r) // same reference (in-memory)
+  })
+
+  it('returns undefined for unknown id', async () => {
+    const store = createPartialDeploymentStore()
+    expect(await store.get('QmNope')).toBeUndefined()
+  })
+
+  it('markUploaded mutates the record uploadedHashes set', async () => {
+    const store = createPartialDeploymentStore()
+    const r = makeRecord('QmE', Date.now() + 60_000)
+    await store.put(r)
+    await store.markUploaded('QmE', 'QmA')
+    expect((await store.get('QmE'))!.uploadedHashes.has('QmA')).toBe(true)
+  })
+
+  it('markUploaded throws if the deployment is unknown', async () => {
+    const store = createPartialDeploymentStore()
+    await expect(store.markUploaded('QmNope', 'QmA')).rejects.toThrow(/not found/i)
+  })
+
+  it('delete removes the record', async () => {
+    const store = createPartialDeploymentStore()
+    await store.put(makeRecord('QmE', Date.now() + 60_000))
+    await store.delete('QmE')
+    expect(await store.get('QmE')).toBeUndefined()
+  })
+
+  it('listExpiredBefore returns entityIds older than the cutoff', async () => {
+    const store = createPartialDeploymentStore()
+    await store.put(makeRecord('Old', 100))
+    await store.put(makeRecord('New', 500))
+    expect((await store.listExpiredBefore(200)).sort()).toEqual(['Old'])
+    expect((await store.listExpiredBefore(1000)).sort()).toEqual(['New', 'Old'])
+  })
+
+  it('clear empties the store', async () => {
+    const store = createPartialDeploymentStore()
+    await store.put(makeRecord('A', 1))
+    await store.put(makeRecord('B', 1))
+    await store.clear()
+    expect(await store.get('A')).toBeUndefined()
+    expect(await store.get('B')).toBeUndefined()
+  })
+})

--- a/test/unit/partial-deployment-sweeper.spec.ts
+++ b/test/unit/partial-deployment-sweeper.spec.ts
@@ -2,7 +2,11 @@ import { createPartialDeploymentStore } from '../../src/adapters/partial-deploym
 import { createPartialDeploymentSweeper } from '../../src/adapters/partial-deployment-sweeper'
 
 const baseLogger: any = {
-  log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {}
+  log: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {}
 }
 
 describe('partialDeploymentSweeper', () => {
@@ -10,15 +14,23 @@ describe('partialDeploymentSweeper', () => {
     const store = createPartialDeploymentStore()
     await store.put({
       entityId: 'old',
-      authChain: [], ownerAddress: '0x', manifest: {},
-      uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
-      deploymentToken: 't', expiresAt: Date.now() - 10_000
+      authChain: [],
+      ownerAddress: '0x',
+      manifest: {},
+      uploadedHashes: new Set(),
+      alreadyAvailableHashes: new Set(),
+      deploymentToken: 't',
+      expiresAt: Date.now() - 10_000
     })
     await store.put({
       entityId: 'new',
-      authChain: [], ownerAddress: '0x', manifest: {},
-      uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
-      deploymentToken: 't', expiresAt: Date.now() + 60_000
+      authChain: [],
+      ownerAddress: '0x',
+      manifest: {},
+      uploadedHashes: new Set(),
+      alreadyAvailableHashes: new Set(),
+      deploymentToken: 't',
+      expiresAt: Date.now() + 60_000
     })
 
     const onCleanup = jest.fn().mockResolvedValue(undefined)
@@ -40,9 +52,13 @@ describe('partialDeploymentSweeper', () => {
     for (const id of ['a', 'b', 'c']) {
       await store.put({
         entityId: id,
-        authChain: [], ownerAddress: '0x', manifest: {},
-        uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
-        deploymentToken: 't', expiresAt: Date.now() - 1
+        authChain: [],
+        ownerAddress: '0x',
+        manifest: {},
+        uploadedHashes: new Set(),
+        alreadyAvailableHashes: new Set(),
+        deploymentToken: 't',
+        expiresAt: Date.now() - 1
       })
     }
     const onCleanup = jest.fn().mockImplementation(async (id: string) => {

--- a/test/unit/partial-deployment-sweeper.spec.ts
+++ b/test/unit/partial-deployment-sweeper.spec.ts
@@ -1,0 +1,62 @@
+import { createPartialDeploymentStore } from '../../src/adapters/partial-deployment-store'
+import { createPartialDeploymentSweeper } from '../../src/adapters/partial-deployment-sweeper'
+
+const baseLogger: any = {
+  log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {}
+}
+
+describe('partialDeploymentSweeper', () => {
+  it('removes expired records on tick', async () => {
+    const store = createPartialDeploymentStore()
+    await store.put({
+      entityId: 'old',
+      authChain: [], ownerAddress: '0x', manifest: {},
+      uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
+      deploymentToken: 't', expiresAt: Date.now() - 10_000
+    })
+    await store.put({
+      entityId: 'new',
+      authChain: [], ownerAddress: '0x', manifest: {},
+      uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
+      deploymentToken: 't', expiresAt: Date.now() + 60_000
+    })
+
+    const onCleanup = jest.fn().mockResolvedValue(undefined)
+    const sweeper = createPartialDeploymentSweeper(
+      { partialDeploymentStore: store, logs: { getLogger: () => baseLogger } as any },
+      { intervalMs: 1_000_000, onCleanupExpiredEntity: onCleanup }
+    )
+
+    await sweeper.runOnce()
+
+    expect(onCleanup).toHaveBeenCalledTimes(1)
+    expect(onCleanup).toHaveBeenCalledWith('old')
+    expect(await store.get('old')).toBeUndefined()
+    expect(await store.get('new')).toBeDefined()
+  })
+
+  it('survives a failure in onCleanupExpiredEntity (continues with the next id)', async () => {
+    const store = createPartialDeploymentStore()
+    for (const id of ['a', 'b', 'c']) {
+      await store.put({
+        entityId: id,
+        authChain: [], ownerAddress: '0x', manifest: {},
+        uploadedHashes: new Set(), alreadyAvailableHashes: new Set(),
+        deploymentToken: 't', expiresAt: Date.now() - 1
+      })
+    }
+    const onCleanup = jest.fn().mockImplementation(async (id: string) => {
+      if (id === 'b') throw new Error('boom')
+    })
+    const sweeper = createPartialDeploymentSweeper(
+      { partialDeploymentStore: store, logs: { getLogger: () => baseLogger } as any },
+      { intervalMs: 1_000_000, onCleanupExpiredEntity: onCleanup }
+    )
+
+    await sweeper.runOnce()
+    expect(onCleanup).toHaveBeenCalledTimes(3)
+    expect(await store.get('a')).toBeUndefined()
+    expect(await store.get('b')).toBeUndefined()
+    expect(await store.get('c')).toBeUndefined()
+  })
+})

--- a/test/unit/partial-deployment-temp-storage.spec.ts
+++ b/test/unit/partial-deployment-temp-storage.spec.ts
@@ -1,0 +1,37 @@
+import { createInMemoryStorage } from '@dcl/catalyst-storage'
+import { createPartialDeploymentTempStorage } from '../../src/adapters/partial-deployment-temp-storage'
+
+describe('createPartialDeploymentTempStorage', () => {
+  it('round-trips entityRaw under a per-entity prefix', async () => {
+    const storage = createInMemoryStorage()
+    const temp = createPartialDeploymentTempStorage({ storage })
+    await temp.putEntityRaw('QmEntity', Buffer.from('{"x":1}'))
+    const got = await temp.getEntityRaw('QmEntity')
+    expect(got.toString()).toBe('{"x":1}')
+  })
+
+  it('round-trips file blobs', async () => {
+    const storage = createInMemoryStorage()
+    const temp = createPartialDeploymentTempStorage({ storage })
+    await temp.putFile('QmEntity', 'QmA', Buffer.from([1, 2, 3]))
+    const got = await temp.getFile('QmEntity', 'QmA')
+    expect([...got]).toEqual([1, 2, 3])
+  })
+
+  it("keeps two deployments' files isolated by entityId", async () => {
+    const storage = createInMemoryStorage()
+    const temp = createPartialDeploymentTempStorage({ storage })
+    await temp.putFile('QmA-deployment', 'QmFile', Buffer.from([1]))
+    await temp.putFile('QmB-deployment', 'QmFile', Buffer.from([9]))
+    expect([...await temp.getFile('QmA-deployment', 'QmFile')]).toEqual([1])
+    expect([...await temp.getFile('QmB-deployment', 'QmFile')]).toEqual([9])
+  })
+
+  it('deleteAll removes the entity raw', async () => {
+    const storage = createInMemoryStorage()
+    const temp = createPartialDeploymentTempStorage({ storage })
+    await temp.putEntityRaw('QmE', Buffer.from('e'))
+    await temp.deleteAll('QmE')
+    await expect(temp.getEntityRaw('QmE')).rejects.toThrow()
+  })
+})

--- a/test/unit/partial-deployment-temp-storage.spec.ts
+++ b/test/unit/partial-deployment-temp-storage.spec.ts
@@ -23,8 +23,8 @@ describe('createPartialDeploymentTempStorage', () => {
     const temp = createPartialDeploymentTempStorage({ storage })
     await temp.putFile('QmA-deployment', 'QmFile', Buffer.from([1]))
     await temp.putFile('QmB-deployment', 'QmFile', Buffer.from([9]))
-    expect([...await temp.getFile('QmA-deployment', 'QmFile')]).toEqual([1])
-    expect([...await temp.getFile('QmB-deployment', 'QmFile')]).toEqual([9])
+    expect([...(await temp.getFile('QmA-deployment', 'QmFile'))]).toEqual([1])
+    expect([...(await temp.getFile('QmB-deployment', 'QmFile'))]).toEqual([9])
   })
 
   it('deleteAll removes the entity raw', async () => {

--- a/test/unit/partial-deployment-validator.spec.ts
+++ b/test/unit/partial-deployment-validator.spec.ts
@@ -1,0 +1,95 @@
+import { createPartialDeploymentValidator } from '../../src/logic/validations/partial-deployment-validator'
+import { PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES } from '../../src/types'
+import { Entity } from '@dcl/schemas'
+
+/** Minimal stub for the v1 Validator components needed by createPartialDeploymentValidator. */
+function makeComponents(validateFn = jest.fn().mockResolvedValue({ ok: () => true, errors: [] })) {
+  return {
+    config: { getString: jest.fn(), getNumber: jest.fn(), requireString: jest.fn(), requireNumber: jest.fn() },
+    limitsManager: {
+      getAllowSdk6For: jest.fn().mockResolvedValue(true),
+      getMaxAllowedParcelsFor: jest.fn().mockResolvedValue(100),
+      getMaxAllowedSizeInBytesFor: jest.fn().mockResolvedValue(BigInt(100 * 1024 * 1024))
+    },
+    nameDenyListChecker: {
+      getBannedNames: jest.fn().mockResolvedValue([]),
+      checkNameDenyList: jest.fn().mockResolvedValue(false)
+    },
+    namePermissionChecker: { checkPermission: jest.fn().mockResolvedValue(true) },
+    permissions: {},
+    storage: { existMultiple: jest.fn().mockResolvedValue(new Map()) },
+    worldsManager: {},
+    _validateFn: validateFn
+  } as any
+}
+
+const baseEntity: Entity = {
+  id: 'QmTest',
+  timestamp: Date.now(),
+  version: 'v3',
+  type: 'scene' as any,
+  pointers: ['0,0'],
+  content: []
+}
+
+describe('createPartialDeploymentValidator.preflight', () => {
+  it('rejects when any manifest entry exceeds per-file size limit', async () => {
+    const validateSpy = jest.fn().mockResolvedValue({ ok: () => true, errors: [] })
+    const components = makeComponents(validateSpy)
+    // Override v1 validator via monkey-patching is not straightforward since
+    // createValidator is called internally. We test the size-rejection path
+    // which short-circuits before calling v1 — so validateSpy should NOT be called.
+    // We use a real validator and check the returned ValidationResult.
+    const validator = createPartialDeploymentValidator(components)
+    const oversizedHash = 'QmOversized'
+    const oversizedSize = PARTIAL_DEPLOYMENT_DEFAULT_FILE_LIMIT_BYTES + 1
+    const result = await validator.preflight({
+      entity: baseEntity,
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      fileSizesManifest: { [oversizedHash]: oversizedSize },
+      contentHashesInStorage: new Map()
+    })
+    expect(result.ok()).toBe(false)
+    expect(result.errors.join(' ')).toMatch(new RegExp(oversizedHash))
+    expect(result.errors.join(' ')).toMatch(/size limit/i)
+  })
+
+  it('passes manifest with all files within limit to v1 validator', async () => {
+    const validator = createPartialDeploymentValidator(makeComponents())
+    const result = await validator.preflight({
+      entity: baseEntity,
+      entityRaw: Buffer.from('{}'),
+      authChain: [],
+      fileSizesManifest: { QmSmall: 100 },
+      contentHashesInStorage: new Map()
+    })
+    // The v1 validator internally may fail for other reasons (missing world name etc.)
+    // but we only care that the size check did not short-circuit it.
+    // If ok() is false the errors should NOT mention "size limit".
+    if (!result.ok()) {
+      expect(result.errors.join(' ')).not.toMatch(/size limit/i)
+    }
+  })
+
+  it('includes entityRaw in the files map keyed by entity.id when delegating to v1', async () => {
+    // We cannot easily spy on the internal v1 validator's validate() call without
+    // dependency injection, but we can verify the preflight doesn't throw and
+    // that an empty manifest (no oversized files) reaches v1 without the size guard
+    // short-circuiting it.
+    const validator = createPartialDeploymentValidator(makeComponents())
+    const entityRaw = Buffer.from(JSON.stringify({ content: [] }))
+    // Should not throw; the result may be ok or not depending on v1 validations.
+    const result = await validator.preflight({
+      entity: baseEntity,
+      entityRaw,
+      authChain: [],
+      fileSizesManifest: {},
+      contentHashesInStorage: new Map()
+    })
+    // Regardless of v1 outcome, the size guard should not have triggered.
+    if (!result.ok()) {
+      expect(result.errors.join(' ')).not.toMatch(/size limit/i)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Implements the v2 partial/resumable scene deployment protocol on the server side. Three new sub-routes under `/entities/...` for file upload, finalize, and status; the existing `POST /entities` dispatches between v1 (today's full multipart) and v2 (init with `Upload-Incomplete: ?1` header) so there's no `/v2/` URL namespace.
- Refresh + supersede of #298 (open since August 2024). Several bugs from that draft are explicitly fixed and regression-tested; no per-file signing (redundant given content-addressed integrity check); finalization is `POST /entities/:id`.
- Companion to `decentraland/catalyst-client#486`. Together they form the client+server pair for the Phase 1 Worlds rollout. Phase 2 (Genesis Catalyst) is tracked as a follow-up.

## Protocol shape

Capability-based, no `/v2/` URL namespace:

| # | Endpoint | Purpose | Status |
|---|---|---|---|
| 1 | `POST /entities` (`Upload-Incomplete: ?1`) | v2 init — manifest only; server returns `{availableFiles, missingFiles, deploymentToken, expiresAt}` | 202 |
| 2 | `POST /entities/:entityId/files/:fileHash` | parallel file uploads, hash-validated against signed manifest | 204 |
| 3 | `POST /entities/:entityId` | finalize — runs full v1 validator, deploys via existing `entityDeployer` | 200 |
| 4 | `GET /entities/:entityId/status` | active-deployment lookup | 200 / 404 |

Spec: `docs/superpowers/specs/2026-05-05-partial-resumable-deploy-protocol-design.md` in the workspace.

## Backward compatibility

- v1 path in `deploy-entity-handler.ts` is **byte-for-byte unchanged** below the new 4-line dispatcher. v1 multipart deploys continue to work identically.
- New sub-routes are registered AFTER `/entities/active` so the parameter `:entityId` doesn't catch the literal segment.
- No database changes, no migration.

## Architecture

- `src/adapters/partial-deployment-store.ts` — in-memory metadata store (Phase 2 swap-in for Redis is one-file)
- `src/adapters/partial-deployment-temp-storage.ts` — wraps `@dcl/catalyst-storage` under `temp/partial/{entityId}/...`. Works with local FS + S3 backends.
- `src/adapters/partial-deployment-mutex.ts` — per-`entityId` mutex (no external dep)
- `src/adapters/partial-deployment-manager.ts` — orchestrator: `init / addFile / complete / status` with idempotent re-init by wallet, lazy + scheduled eviction, hash + size + manifest-membership validation
- `src/adapters/partial-deployment-sweeper.ts` — 5-min interval, 15-min TTL eviction; auto-started by `well-known-components` lifecycle
- `src/logic/validations/partial-deployment-validator.ts` — `preflight` (init: per-file size + v1 validation pass) + `final` (finalize: full v1 validation including auth-chain)
- `src/controllers/handlers/deploy-v2-handlers.ts` — 4 thin HTTP handlers

## What changed vs the 2024 draft (#298)

This branch fixes (regression-tested) and modernizes the original draft:

- **Inverted hash check bug** (would have accepted any bytes under any hash) → strict `hashV1(bytes) === fileHash` check
- **`tempFiles` collision across deployments** (cleanup of one wiped the other) → keys namespaced under `entityId`
- **`finally` block null-ref** → null-safe via dedicated `deleteAll(record)` helper
- **No purging strategy** → 5-min interval sweeper with 15-min TTL + lazy eviction on access
- **No per-request size limit** → `Content-Length` checked against limit BEFORE buffering body
- **Two divergent validators** → one unified `IPartialDeploymentValidator` with `preflight` + `final`
- **Debug `logRequestMiddleware`** → never reintroduced
- **`creationTimestamp` consistency** → finalize uses the same shape as v1's response
- **Idempotent init** → re-init from same wallet returns the original `deploymentToken`; re-init from different wallet → 400
- **Finalize used `PUT` with empty-string body** → finalize is `POST /entities/:id` with no body, matching the original shape doc

In addition, an Opus-level code review found 7 issues addressed before push:
- Critical: entity raw must be in the validator's `files` map (was missing — would have failed integration tests)
- Critical: per-request size limit before `ctx.request.buffer()` (closed a DoS hole)
- Critical: `addFile`'s expired branch was leaking file blobs (now uses `deleteAll(record)`)
- Important: `preflight` now enforces per-file size from the manifest at init
- Important: `complete` cleanup moved out of `finally` so transient deploy failures preserve the record for retry
- Important: `404` (not `400`) for unknown/expired deployments — required for catalyst-client's `resumeOnEviction` path
- Minor: `as any` cast on dispatcher dropped

## Test plan

- [x] 652/652 unit tests pass (37 suites)
- [x] Lint clean, build clean
- [ ] **Integration tests need PostgreSQL via `yarn start:db`** — they were not run locally because Docker wasn't available; they will run on CI and during manual testing
- [ ] Manual test in `zone` (creator deploys a small + medium + large scene against this branch + `decentraland/catalyst-client#486`'s branch)
- [ ] Six-scene checklist from the spec section 7 rollout step 3a

## Out of scope (tracked separately)

- `decentraland/catalyst-api-specs` OpenAPI additions (separate plan A)
- `decentraland/js-sdk-toolchain` (`@dcl/sdk-commands`) integration (separate plan D, depends on catalyst-client being publishable from the branch)
- Genesis Catalyst v2 adoption (Phase 2 — same protocol, sticky-sessions for multi-replica)
- `DEPLOYMENT_V2_ENABLED` kill-switch env flag — deferred per the plan; v1 is preserved as the escape hatch and the routes can be disabled via revert if needed

## Key file additions

```
src/adapters/partial-deployment-{mutex,store,temp-storage,manager,sweeper}.ts
src/logic/validations/partial-deployment-validator.ts
src/controllers/handlers/deploy-v2-handlers.ts
test/unit/partial-deployment-{mutex,store,temp-storage,manager,sweeper,validator}.spec.ts
test/integration/deploy-v2.spec.ts
test/integration/deploy-v2-failures.spec.ts
```