### PR TITLE
fix: harden world content endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ node_modules/
 **/.DS_Store
 coverage
 contents
-.env
+.env*
+!.env.default
+!.env.example
 yarn-error.log
 
 # Generated API client

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@well-known-components/nats-component": "^2.0.0",
     "@well-known-components/thegraph-component": "^1.6.0",
     "aws-sdk": "^2.1545.0",
-    "bcrypt": "^5.1.1",
+    "bcrypt": "^6.0.0",
     "busboy": "^1.6.0",
     "cron": "^3.1.6",
     "eth-connect": "^6.2.4",

--- a/src/components.ts
+++ b/src/components.ts
@@ -270,7 +270,7 @@ export async function initComponents(): Promise<AppComponents> {
   for (const subType of COMMUNITY_MEMBER_REMOVED_EVENT_SUBTYPES) {
     queueConsumer.addMessageHandler(Events.Type.COMMUNITY, subType, communityMemberRemovedHandler.handle)
   }
-  const rateLimiter = await createRateLimiterComponent({ config, redis })
+  const rateLimiter = await createRateLimiterComponent({ config, logs, redis })
 
   return {
     access,

--- a/src/controllers/handlers/comms-adapter-handler.ts
+++ b/src/controllers/handlers/comms-adapter-handler.ts
@@ -2,6 +2,9 @@ import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
 import { InvalidRequestError, NotAuthorizedError, NotFoundError } from '@dcl/http-commons'
+import { AccessType } from '../../logic/access'
+import { RATE_LIMIT_WINDOW_SECONDS } from '../../logic/rate-limiter'
+import { extractCommsRateLimitSubject } from './comms-rate-limit-subject'
 
 type CommsMetadata = {
   secret?: string
@@ -9,13 +12,13 @@ type CommsMetadata = {
 
 export async function commsAdapterHandler(
   context: HandlerContextWithPath<
-    'access' | 'commsAdapter' | 'config' | 'namePermissionChecker' | 'worlds',
+    'access' | 'commsAdapter' | 'config' | 'namePermissionChecker' | 'rateLimiter' | 'worlds',
     '/get-comms-adapter/:roomId'
   > &
     DecentralandSignatureContext<CommsMetadata>
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { access, commsAdapter, config, namePermissionChecker, worlds }
+    components: { access, commsAdapter, config, namePermissionChecker, rateLimiter, worlds }
   } = context
 
   const authMetadata = context.verification!.authMetadata
@@ -36,13 +39,39 @@ export async function commsAdapterHandler(
   }
 
   const identity = context.verification!.auth
+  const subject = extractCommsRateLimitSubject(context.request, identity)
+  const accessSetting = await access.getAccessForWorld(worldName)
+  const isSharedSecret = accessSetting.type === AccessType.SharedSecret
+
+  if (isSharedSecret && (await rateLimiter.isRateLimited(worldName, subject))) {
+    return {
+      status: 429,
+      headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_SECONDS) },
+      body: { error: 'Too many shared-secret attempts. Try again later.' }
+    }
+  }
+
   const [hasPermission, hasAccess] = await Promise.all([
     namePermissionChecker.checkPermission(identity, worldName),
     access.checkAccess(worldName, identity, authMetadata.secret)
   ])
 
   if (!hasPermission && !hasAccess) {
+    if (isSharedSecret) {
+      const { rateLimited } = await rateLimiter.recordFailedAttempt(worldName, subject)
+      if (rateLimited) {
+        return {
+          status: 429,
+          headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_SECONDS) },
+          body: { error: 'Too many shared-secret attempts. Try again later.' }
+        }
+      }
+    }
     throw new NotAuthorizedError(`You are not allowed to access world "${worldName}".`)
+  }
+
+  if (isSharedSecret) {
+    await rateLimiter.clearAttempts(worldName, subject)
   }
 
   return {

--- a/src/controllers/handlers/comms-rate-limit-subject.ts
+++ b/src/controllers/handlers/comms-rate-limit-subject.ts
@@ -1,0 +1,5 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+
+export function extractCommsRateLimitSubject(request: IHttpServerComponent.IRequest, identity: string): string {
+  return request.headers.get('cf-connecting-ip') || identity
+}

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -2,8 +2,10 @@ import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { IPFSv2 } from '@dcl/schemas'
 import { HandlerContextWithPath } from '../../types'
 import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { InvalidRequestError } from '@dcl/http-commons'
 
 const EXPOSED_HEADERS = 'ETag, Accept-Ranges, Content-Range'
+export const MAX_AVAILABLE_CONTENT_CIDS = 500
 
 function contentItemHeaders(content: ContentItem, hashId: string) {
   const ret: Record<string, string> = {
@@ -155,6 +157,20 @@ export async function availableContentHandler(
 ): Promise<IHttpServerComponent.IResponse> {
   const params = new URLSearchParams(ctx.url.search)
   const cids = params.getAll('cid')
+
+  if (cids.length === 0) {
+    throw new InvalidRequestError('At least one cid query parameter is required.')
+  }
+
+  if (cids.length > MAX_AVAILABLE_CONTENT_CIDS) {
+    throw new InvalidRequestError(`Too many cid query parameters. Maximum allowed is ${MAX_AVAILABLE_CONTENT_CIDS}.`)
+  }
+
+  for (const cid of cids) {
+    if (!IPFSv2.validate(cid)) {
+      throw new InvalidRequestError('Invalid cid format.')
+    }
+  }
 
   const results = Array.from((await ctx.components.storage.existMultiple(cids)).entries())
 

--- a/src/controllers/handlers/world-comms-handler.ts
+++ b/src/controllers/handlers/world-comms-handler.ts
@@ -12,17 +12,14 @@ import {
 } from '../../logic/comms'
 import { AccessType } from '../../logic/access'
 import { RATE_LIMIT_WINDOW_SECONDS, RateLimitedError } from '../../logic/rate-limiter'
+import { extractCommsRateLimitSubject } from './comms-rate-limit-subject'
 
 type CommsMetadata = {
   secret?: string
 }
 
-function extractClientIp(request: IHttpServerComponent.IRequest): string | undefined {
-  return request.headers.get('cf-connecting-ip') ?? undefined
-}
-
 function extractSubject(context: HandlerContext): string {
-  return extractClientIp(context.request) || context.verification!.auth
+  return extractCommsRateLimitSubject(context.request, context.verification!.auth)
 }
 
 type HandlerContext = HandlerContextWithPath<

--- a/src/controllers/schemas/scenes-query-schemas.ts
+++ b/src/controllers/schemas/scenes-query-schemas.ts
@@ -1,6 +1,7 @@
 import type { Schema } from 'ajv'
 
 const COORDINATE_PATTERN = '^-?\\d+,-?\\d+$'
+const MAX_COORDINATES_PER_REQUEST = 500
 
 export type GetWorldScenesRequestBody = {
   coordinates: string[]
@@ -14,7 +15,10 @@ export const getWorldScenesSchema: Schema = {
       items: {
         type: 'string',
         pattern: COORDINATE_PATTERN
-      }
+      },
+      minItems: 1,
+      maxItems: MAX_COORDINATES_PER_REQUEST,
+      uniqueItems: true
     }
   },
   required: ['coordinates'],

--- a/src/logic/rate-limiter/component.ts
+++ b/src/logic/rate-limiter/component.ts
@@ -17,8 +17,10 @@ type StoredAttempts = {
 
 export async function createRateLimiterComponent({
   config,
+  logs,
   redis
-}: Pick<AppComponents, 'config' | 'redis'>): Promise<IRateLimiterComponent> {
+}: Pick<AppComponents, 'config' | 'logs' | 'redis'>): Promise<IRateLimiterComponent> {
+  const logger = logs.getLogger('rate-limiter')
   const maxAttempts =
     (await config.getNumber('SHARED_SECRET_MAX_ATTEMPTS_PER_MINUTE')) ?? DEFAULT_MAX_ATTEMPTS_PER_MINUTE
 
@@ -38,7 +40,12 @@ export async function createRateLimiterComponent({
       const stored = await redis.get<StoredAttempts>(attemptsKey)
       const recentAttempts = stored ? stored.attempts.filter((ts) => ts > windowStart) : []
       return recentAttempts.length >= maxAttempts
-    } catch {
+    } catch (error) {
+      logger.warn('Failed to check shared-secret rate limit, allowing request', {
+        worldName,
+        subject,
+        error: error instanceof Error ? error.message : String(error)
+      })
       return false // fail-open
     }
   }
@@ -67,11 +74,24 @@ export async function createRateLimiterComponent({
       await redis.set<StoredAttempts>(attemptsKey, { attempts: recentAttempts }, RATE_LIMIT_TTL_SECONDS)
 
       return { rateLimited: false }
-    } catch {
+    } catch (error) {
+      logger.warn('Failed to record shared-secret rate limit attempt, allowing request', {
+        worldName,
+        subject,
+        error: error instanceof Error ? error.message : String(error)
+      })
       // If lock acquisition fails, don't block the caller — just skip tracking
       return { rateLimited: false }
     } finally {
-      await redis.tryReleaseLock(lockKey)
+      try {
+        await redis.tryReleaseLock(lockKey)
+      } catch (error) {
+        logger.warn('Failed to release shared-secret rate limit lock', {
+          worldName,
+          subject,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
     }
   }
 

--- a/test/components.ts
+++ b/test/components.ts
@@ -197,7 +197,7 @@ async function initComponents(): Promise<TestComponents> {
   const evictionJob = { start: jest.fn(), stop: jest.fn() }
 
   const redis = createRedisMock()
-  const rateLimiter = await createRateLimiterComponent({ config, redis })
+  const rateLimiter = await createRateLimiterComponent({ config, logs, redis })
 
   const denyList = createMockDenyList()
   const bans = createMockBans()

--- a/test/integration/comms-adapter-handler.spec.ts
+++ b/test/integration/comms-adapter-handler.spec.ts
@@ -4,6 +4,7 @@ import { getAuthHeaders, getIdentity, Identity } from '../utils'
 import { IAuthenticatedFetchComponent } from '../components/local-auth-fetch'
 import { IWorldsManager } from '../../src/types'
 import { AccessType } from '../../src/logic/access'
+import bcrypt from 'bcrypt'
 
 const EXPLORER_METADATA = {
   origin: 'https://play.decentraland.org',
@@ -39,6 +40,10 @@ test('comms adapter handler /get-comms-adapter/:roomId', function ({ components,
 
     const created = await worldCreator.createWorldWithScene()
     worldName = created.worldName
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it('works when signed-fetch request is correct', async () => {
@@ -179,6 +184,115 @@ test('comms adapter handler /get-comms-adapter/:roomId', function ({ components,
     expect(await r.json()).toEqual({
       error: 'Invalid Auth Chain',
       message: 'This endpoint requires a signed fetch request. See ADR-44.'
+    })
+  })
+
+  describe('when the world uses shared-secret access', function () {
+    beforeEach(async () => {
+      const { namePermissionChecker } = stubComponents
+
+      namePermissionChecker.checkPermission.resolves(false)
+      await worldsManager.storeAccess(worldName, {
+        type: AccessType.SharedSecret,
+        secret: bcrypt.hashSync('correct-secret', 10)
+      })
+    })
+
+    describe('and the subject is already rate limited', function () {
+      let response: Response
+
+      beforeEach(async () => {
+        jest.spyOn(components.rateLimiter, 'isRateLimited').mockResolvedValueOnce(true)
+
+        response = await localFetch.fetch(`/get-comms-adapter/world-${worldName}`, {
+          method: 'POST',
+          identity,
+          metadata: { ...EXPLORER_METADATA, secret: 'wrong-secret' }
+        })
+      })
+
+      it('should respond with 429', async () => {
+        expect(response.status).toEqual(429)
+      })
+
+      it('should include a retry-after header', async () => {
+        expect(response.headers.get('retry-after')).toEqual('60')
+      })
+    })
+
+    describe('and the failed attempt reaches the rate limit', function () {
+      let response: Response
+
+      beforeEach(async () => {
+        jest.spyOn(components.rateLimiter, 'isRateLimited').mockResolvedValueOnce(false)
+        jest.spyOn(components.rateLimiter, 'recordFailedAttempt').mockResolvedValueOnce({ rateLimited: true })
+
+        response = await localFetch.fetch(`/get-comms-adapter/world-${worldName}`, {
+          method: 'POST',
+          identity,
+          metadata: { ...EXPLORER_METADATA, secret: 'wrong-secret' }
+        })
+      })
+
+      it('should respond with 429', async () => {
+        expect(response.status).toEqual(429)
+      })
+
+      it('should include a retry-after header', async () => {
+        expect(response.headers.get('retry-after')).toEqual('60')
+      })
+    })
+
+    describe('and the request includes a Cloudflare connecting IP', function () {
+      let response: Response
+      let isRateLimitedSpy: jest.SpyInstance
+      let recordFailedAttemptSpy: jest.SpyInstance
+      let clientIp: string
+
+      beforeEach(async () => {
+        clientIp = '203.0.113.10'
+        isRateLimitedSpy = jest.spyOn(components.rateLimiter, 'isRateLimited').mockResolvedValueOnce(false)
+        recordFailedAttemptSpy = jest
+          .spyOn(components.rateLimiter, 'recordFailedAttempt')
+          .mockResolvedValueOnce({ rateLimited: false })
+
+        response = await localFetch.fetch(`/get-comms-adapter/world-${worldName}`, {
+          method: 'POST',
+          identity,
+          headers: { 'cf-connecting-ip': clientIp },
+          metadata: { ...EXPLORER_METADATA, secret: 'wrong-secret' }
+        })
+      })
+
+      it('should use the IP as the rate limit subject', async () => {
+        expect(response.status).toEqual(401)
+        expect(isRateLimitedSpy).toHaveBeenCalledWith(worldName, clientIp)
+        expect(recordFailedAttemptSpy).toHaveBeenCalledWith(worldName, clientIp)
+      })
+    })
+
+    describe('and the shared secret is correct', function () {
+      let response: Response
+      let clearAttemptsSpy: jest.SpyInstance
+
+      beforeEach(async () => {
+        jest.spyOn(components.rateLimiter, 'isRateLimited').mockResolvedValueOnce(false)
+        clearAttemptsSpy = jest.spyOn(components.rateLimiter, 'clearAttempts')
+
+        response = await localFetch.fetch(`/get-comms-adapter/world-${worldName}`, {
+          method: 'POST',
+          identity,
+          metadata: { ...EXPLORER_METADATA, secret: 'correct-secret' }
+        })
+      })
+
+      it('should respond with 200', async () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should clear failed attempts for the signer', async () => {
+        expect(clearAttemptsSpy).toHaveBeenCalledWith(worldName, identity.realAccount.address.toLowerCase())
+      })
     })
   })
 })

--- a/test/integration/scenes-handler.spec.ts
+++ b/test/integration/scenes-handler.spec.ts
@@ -132,6 +132,46 @@ test('ScenesHandler', function ({ components, stubComponents }) {
           })
         })
 
+        describe('and too many coordinates are provided', function () {
+          let coordinates: string[]
+
+          beforeEach(() => {
+            coordinates = Array.from({ length: 501 }, (_, index) => `${index},${index}`)
+          })
+
+          it('should respond with 400', async () => {
+            const { localFetch } = components
+
+            const response = await localFetch.fetch(`/world/${worldName}/scenes`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ coordinates })
+            })
+
+            expect(response.status).toBe(400)
+          })
+        })
+
+        describe('and the maximum number of coordinates is provided', function () {
+          let coordinates: string[]
+
+          beforeEach(() => {
+            coordinates = Array.from({ length: 500 }, (_, index) => `${index},${index}`)
+          })
+
+          it('should accept the request', async () => {
+            const { localFetch } = components
+
+            const response = await localFetch.fetch(`/world/${worldName}/scenes`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ coordinates })
+            })
+
+            expect(response.status).toBe(200)
+          })
+        })
+
         describe('and one of multiple coordinates is invalid', function () {
           let coordinates: string[]
 

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -1,6 +1,11 @@
 import { Readable } from 'stream'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
-import { getContentFile, parseRangeHeader } from '../../src/controllers/handlers/content-file-handler'
+import {
+  availableContentHandler,
+  getContentFile,
+  MAX_AVAILABLE_CONTENT_CIDS,
+  parseRangeHeader
+} from '../../src/controllers/handlers/content-file-handler'
 import { HandlerContextWithPath } from '../../src/types'
 import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
 
@@ -399,6 +404,107 @@ describe('getContentFile', () => {
 
     it('should not call fileInfo', () => {
       expect(storageMock.fileInfo).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('availableContentHandler', () => {
+  const validCid = 'bafkreiahsvnr4x4rnskhkwfbnbplkbqhzb3xagdwpyfy44lgcndmhyizde'
+
+  function createContext(
+    storage: Partial<IContentStorageComponent>,
+    search: string
+  ): HandlerContextWithPath<'storage', '/content/available-content'> {
+    return {
+      url: new URL(`http://localhost/available-content${search}`),
+      params: {},
+      request: { headers: new Headers() } as unknown as IHttpServerComponent.IRequest,
+      components: { storage: storage as IContentStorageComponent }
+    }
+  }
+
+  describe('when no cid is provided', () => {
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(() => {
+      storageMock = {
+        existMultiple: jest.fn()
+      }
+    })
+
+    it('should reject the request', async () => {
+      await expect(availableContentHandler(createContext(storageMock, ''))).rejects.toThrow(
+        'At least one cid query parameter is required.'
+      )
+    })
+  })
+
+  describe('when a cid is invalid', () => {
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(() => {
+      storageMock = {
+        existMultiple: jest.fn()
+      }
+    })
+
+    it('should reject the request', async () => {
+      await expect(availableContentHandler(createContext(storageMock, '?cid=invalid'))).rejects.toThrow(
+        'Invalid cid format.'
+      )
+    })
+  })
+
+  describe('when too many cids are provided', () => {
+    let storageMock: Partial<IContentStorageComponent>
+    let search: string
+
+    beforeEach(() => {
+      storageMock = {
+        existMultiple: jest.fn()
+      }
+      search = `?${Array.from({ length: MAX_AVAILABLE_CONTENT_CIDS + 1 }, () => `cid=${validCid}`).join('&')}`
+    })
+
+    it('should reject the request', async () => {
+      await expect(availableContentHandler(createContext(storageMock, search))).rejects.toThrow(
+        `Too many cid query parameters. Maximum allowed is ${MAX_AVAILABLE_CONTENT_CIDS}.`
+      )
+    })
+  })
+
+  describe('when all cids are valid', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      storageMock = {
+        existMultiple: jest.fn().mockResolvedValue(new Map([[validCid, true]]))
+      }
+      response = await availableContentHandler(createContext(storageMock, `?cid=${validCid}`))
+    })
+
+    it('should return availability for the requested cids', () => {
+      expect(response.body).toEqual([{ cid: validCid, available: true }])
+    })
+  })
+
+  describe('when the maximum number of cids is provided', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+    let search: string
+
+    beforeEach(async () => {
+      storageMock = {
+        existMultiple: jest.fn().mockResolvedValue(new Map([[validCid, true]]))
+      }
+      search = `?${Array.from({ length: MAX_AVAILABLE_CONTENT_CIDS }, () => `cid=${validCid}`).join('&')}`
+
+      response = await availableContentHandler(createContext(storageMock, search))
+    })
+
+    it('should accept the request', () => {
+      expect(response.body).toEqual([{ cid: validCid, available: true }])
     })
   })
 })

--- a/test/unit/rate-limiter-component.spec.ts
+++ b/test/unit/rate-limiter-component.spec.ts
@@ -3,10 +3,13 @@ import { IConfigComponent } from '@well-known-components/interfaces'
 import { createRateLimiterComponent, IRateLimiterComponent } from '../../src/logic/rate-limiter'
 import { createRedisMock } from '../mocks/redis-mock'
 import { createMockedConfig } from '../mocks/config-mock'
+import { createMockLogs } from '../mocks/logs-mock'
 
 describe('RateLimiterComponent', () => {
   let redis: jest.Mocked<ICacheStorageComponent>
   let config: jest.Mocked<IConfigComponent>
+  let logs: ReturnType<typeof createMockLogs>
+  let logger: ReturnType<typeof logs.getLogger>
   let rateLimiter: IRateLimiterComponent
 
   const worldName = 'test-world'
@@ -15,9 +18,11 @@ describe('RateLimiterComponent', () => {
   beforeEach(async () => {
     redis = createRedisMock()
     config = createMockedConfig()
+    logs = createMockLogs()
+    logger = logs.getLogger('rate-limiter')
     config.getNumber.mockResolvedValue(3)
 
-    rateLimiter = await createRateLimiterComponent({ config, redis })
+    rateLimiter = await createRateLimiterComponent({ config, logs, redis })
   })
 
   afterEach(() => {
@@ -76,6 +81,15 @@ describe('RateLimiterComponent', () => {
         const result = await rateLimiter.isRateLimited(worldName, subject)
 
         expect(result).toBe(false)
+      })
+
+      it('should log a warning', async () => {
+        await rateLimiter.isRateLimited(worldName, subject)
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Failed to check shared-secret rate limit, allowing request',
+          expect.objectContaining({ worldName, subject, error: 'Redis error' })
+        )
       })
     })
 
@@ -178,12 +192,21 @@ describe('RateLimiterComponent', () => {
         expect(result.rateLimited).toBe(false)
         expect(redis.set).not.toHaveBeenCalled()
       })
+
+      it('should log a warning', async () => {
+        await rateLimiter.recordFailedAttempt(worldName, subject)
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Failed to record shared-secret rate limit attempt, allowing request',
+          expect.objectContaining({ worldName, subject, error: 'Lock not acquired' })
+        )
+      })
     })
 
     describe('when the max attempts config is customized', () => {
       beforeEach(async () => {
         config.getNumber.mockResolvedValue(1)
-        rateLimiter = await createRateLimiterComponent({ config, redis })
+        rateLimiter = await createRateLimiterComponent({ config, logs, redis })
 
         const now = Date.now()
         redis.get.mockResolvedValue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,21 +1356,6 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
-"@mapbox/node-pre-gyp@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz"
-  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
-  dependencies:
-    detect-libc "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.7"
-    nopt "^5.0.0"
-    npmlog "^5.0.1"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.11"
-
 "@noble/hashes@~1.2.0", "@noble/hashes@1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz"
@@ -2601,11 +2586,6 @@
   dependencies:
     "@well-known-components/interfaces" "^1.4.2"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz"
@@ -2634,13 +2614,6 @@ agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
-
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
 
 ajv-errors@^3.0.0:
   version "3.0.0"
@@ -2712,19 +2685,6 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-"aproba@^1.0.3 || ^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz"
-  integrity sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==
-
-are-we-there-yet@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz"
-  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -2879,13 +2839,13 @@ baseline-browser-mapping@^2.9.0:
   resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz"
   integrity sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==
 
-bcrypt@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz"
-  integrity sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==
+bcrypt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz"
+  integrity sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==
   dependencies:
-    "@mapbox/node-pre-gyp" "^1.0.11"
-    node-addon-api "^5.0.0"
+    node-addon-api "^8.3.0"
+    node-gyp-build "^4.8.4"
 
 better-ajv-errors@^1.2.0:
   version "1.2.0"
@@ -3094,11 +3054,6 @@ chokidar@^3.5.1, chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
 ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz"
@@ -3164,11 +3119,6 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-support@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
-
 colorette@^1.2.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz"
@@ -3200,11 +3150,6 @@ concat-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
-
-console-control-strings@^1.0.0, console-control-strings@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -3367,11 +3312,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
-
 depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
@@ -3381,11 +3321,6 @@ destroy@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
-
-detect-libc@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
-  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -3945,13 +3880,6 @@ fp-future@^1.0.1:
   resolved "https://registry.npmjs.org/fp-future/-/fp-future-1.0.1.tgz"
   integrity sha512-2McmZH/KsZqlqHju9+Ox0FC7q7Knve4t6ZeKubbhAz1xpnD7hkCrP8TP5g5QbbD5bA5jBANbXf/ew4x1FjSUrw==
 
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -3966,21 +3894,6 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-gauge@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz"
-  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.2"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.1"
-    object-assign "^4.1.1"
-    signal-exit "^3.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.2"
 
 generator-function@^2.0.0:
   version "2.0.1"
@@ -4166,11 +4079,6 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-has-unicode@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
-
 hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
@@ -4198,14 +4106,6 @@ http2-client@^1.2.5:
   version "1.3.5"
   resolved "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz"
   integrity sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==
-
-https-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
 
 https-proxy-agent@^7.0.5:
   version "7.0.6"
@@ -5049,13 +4949,6 @@ luxon@~3.5.0:
   resolved "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz"
   integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
 
-make-dir@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
-  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
-  dependencies:
-    semver "^6.0.0"
-
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
@@ -5170,13 +5063,6 @@ minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^3.0.0:
-  version "3.3.6"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz"
-  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
-  dependencies:
-    yallist "^4.0.0"
-
 minipass@^4.2.4:
   version "4.2.8"
   resolved "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz"
@@ -5187,33 +5073,15 @@ minipass@^4.2.4:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-minipass@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
-  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
-
 minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
-
 mitt@^3.0.0, mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mobx-react-lite@^4.1.1:
   version "4.1.1"
@@ -5295,10 +5163,10 @@ nkeys.js@1.1.0:
   dependencies:
     tweetnacl "1.0.3"
 
-node-addon-api@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz"
-  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+node-addon-api@^8.3.0:
+  version "8.8.0"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz"
+  integrity sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==
 
 node-fetch-h2@^2.3.0:
   version "2.3.0"
@@ -5307,12 +5175,17 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0, node-fetch@2.x:
+node-fetch@^2.6.1, node-fetch@^2.6.9, node-fetch@^2.7.0, node-fetch@2.x:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5355,13 +5228,6 @@ nodemon@^3.1.11:
     touch "^3.1.0"
     undefsafe "^2.0.5"
 
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
-
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
@@ -5373,16 +5239,6 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-npmlog@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^3.0.0"
-    set-blocking "^2.0.0"
 
 oas-kit-common@^1.0.8:
   version "1.0.8"
@@ -6116,11 +5972,6 @@ scheduler@^0.27.0:
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
-semver@^6.0.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
 semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
@@ -6131,15 +5982,10 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@^7.7.3:
+semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
-
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
 set-cookie-parser@^2.3.5:
   version "2.7.2"
@@ -6224,7 +6070,7 @@ should@^13.2.1:
     should-type-adaptors "^1.0.1"
     should-util "^1.0.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -6371,7 +6217,7 @@ string-similarity@^4.0.3:
   resolved "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6488,18 +6334,6 @@ synckit@^0.11.12:
   integrity sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==
   dependencies:
     "@pkgr/core" "^0.2.9"
-
-tar@^6.1.11:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
 
 tdigest@^0.1.1:
   version "0.1.2"
@@ -6832,13 +6666,6 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.2:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz"
-  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
-  dependencies:
-    string-width "^1.0.2 || 2 || 3 || 4"
-
 word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
@@ -6910,11 +6737,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml-ast-parser@0.0.43:
   version "0.0.43"


### PR DESCRIPTION
## Summary
- rate limit failed shared-secret attempts on the deprecated comms adapter endpoint
- validate and cap /available-content cid queries
- cap and deduplicate POST /world/:world_name/scenes coordinate filters
- upgrade bcrypt to 6.0.0 and update yarn.lock
- ignore local .env variants while preserving examples
