### PR TITLE
fix: harden content endpoints and stream deploy uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@dcl/catalyst-api-specs": "^3.3.0",
     "@dcl/catalyst-contracts": "^4.4.2",
-    "@dcl/catalyst-storage": "^4.5.1",
+    "@dcl/catalyst-storage": "^4.6.1",
     "@dcl/crypto": "^3.4.5",
     "@dcl/hashing": "^3.0.4",
     "@dcl/http-commons": "^1.0.0",

--- a/src/adapters/entity-deployer.ts
+++ b/src/adapters/entity-deployer.ts
@@ -1,4 +1,4 @@
-import { AppComponents, DeploymentResult, IEntityDeployer } from '../types'
+import { AppComponents, DeploymentFile, DeploymentResult, IEntityDeployer } from '../types'
 import { AuthLink, Entity, EntityType, Events, WorldDeploymentEvent } from '@dcl/schemas'
 import { bufferToStream } from '@dcl/catalyst-storage/dist/content-item'
 import { stringToUtf8Bytes } from 'eth-connect'
@@ -18,7 +18,7 @@ export function createEntityDeployer(
     baseUrl: string,
     entity: Entity,
     allContentHashesInStorage: Map<string, boolean>,
-    files: Map<string, Uint8Array>,
+    files: Map<string, DeploymentFile>,
     entityJson: string,
     authChain: AuthLink[]
   ): Promise<DeploymentResult> {
@@ -29,7 +29,7 @@ export function createEntityDeployer(
       if (!allContentHashesInStorage.get(file.hash)) {
         const filename = content.find(($) => $.hash === file.hash)
         logger.info(`Storing file`, { cid: file.hash, filename: filename?.file || 'unknown' })
-        await storage.storeStream(file.hash, bufferToStream(files.get(file.hash)!))
+        await storage.storeStream(file.hash, files.get(file.hash)!.getStream())
         allContentHashesInStorage.set(file.hash, true)
       }
     }

--- a/src/adapters/worlds-indexer.ts
+++ b/src/adapters/worlds-indexer.ts
@@ -1,5 +1,6 @@
 import {
   AppComponents,
+  GetRawWorldRecordsOptions,
   IWorldsIndexer,
   SceneData,
   WorldData,
@@ -12,8 +13,11 @@ import { ContentMapping } from '@dcl/schemas/dist/misc/content-mapping'
 export async function createWorldsIndexerComponent({
   worldsManager
 }: Pick<AppComponents, 'worldsManager'>): Promise<IWorldsIndexer> {
-  async function getIndex(): Promise<WorldsIndex> {
-    const { records: worlds } = await worldsManager.getRawWorldRecords()
+  // The index is built by fanning out one scene query per world, so the number of worlds fetched
+  // bounds the per-request work. Pagination options are forwarded to keep that bound in the
+  // caller's hands (the HTTP handler caps the page size).
+  async function getIndex(options?: GetRawWorldRecordsOptions): Promise<WorldsIndex> {
+    const { records: worlds } = await worldsManager.getRawWorldRecords({}, options)
     const index: WorldData[] = []
 
     for (const world of worlds) {

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -7,6 +7,16 @@ import { InvalidRequestError } from '@dcl/http-commons'
 const EXPOSED_HEADERS = 'ETag, Accept-Ranges, Content-Range'
 export const MAX_AVAILABLE_CONTENT_CIDS = 500
 
+// Content is addressed by IPFS CIDv1, but world thumbnails have historically been stored under a
+// raw SHA-256 hex digest. Accept both when serving so those legacy thumbnails remain retrievable.
+// Both formats are strictly validated and contain no path separators, so neither can escape the
+// storage root.
+const SHA256_HEX = /^[0-9a-f]{64}$/
+
+function isRetrievableContentKey(hashId: string): boolean {
+  return IPFSv2.validate(hashId) || SHA256_HEX.test(hashId)
+}
+
 function contentItemHeaders(content: ContentItem, hashId: string) {
   const ret: Record<string, string> = {
     'Content-Type': 'application/octet-stream',
@@ -79,7 +89,7 @@ async function retrieveFullContent(
 export async function getContentFile(
   ctx: HandlerContextWithPath<'storage', '/contents/:hashId'>
 ): Promise<IHttpServerComponent.IResponse> {
-  if (!IPFSv2.validate(ctx.params.hashId)) return { status: 400 }
+  if (!isRetrievableContentKey(ctx.params.hashId)) return { status: 400 }
 
   const rangeHeader = ctx.request.headers.get('range')
 
@@ -143,7 +153,7 @@ export async function getContentFile(
 export async function headContentFile(
   ctx: HandlerContextWithPath<'storage', '/contents/:hashId'>
 ): Promise<IHttpServerComponent.IResponse> {
-  if (!IPFSv2.validate(ctx.params.hashId)) return { status: 400 }
+  if (!isRetrievableContentKey(ctx.params.hashId)) return { status: 400 }
 
   const file = await ctx.components.storage.retrieve(ctx.params.hashId)
 

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -1,7 +1,7 @@
 import { Entity } from '@dcl/schemas'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
-import { FormDataContext } from '../../logic/multipart'
-import { HandlerContextWithPath } from '../../types'
+import { FormDataContext, readUploadedFile, toDeploymentFile } from '../../logic/multipart'
+import { DeploymentFile, HandlerContextWithPath } from '../../types'
 import { extractAuthChain } from '../../logic/extract-auth-chain'
 import { InvalidRequestError } from '@dcl/http-commons'
 
@@ -16,7 +16,12 @@ export async function deployEntity(
   const entityId = requireString(ctx.formData.fields.entityId?.value[0])
   const authChain = extractAuthChain(ctx)
 
-  const entityRaw = ctx.formData.files[entityId].value.toString()
+  const entityFile = ctx.formData.files[entityId]
+  if (!entityFile) {
+    throw new InvalidRequestError(`Entity file ${entityId} is missing from the upload.`)
+  }
+  // The entity JSON is small, so it is safe to read fully into memory.
+  const entityRaw = (await readUploadedFile(entityFile)).toString()
   const entityMetadataJson = JSON.parse(entityRaw)
 
   const entity: Entity = {
@@ -24,9 +29,9 @@ export async function deployEntity(
     ...entityMetadataJson
   }
 
-  const uploadedFiles: Map<string, Uint8Array> = new Map()
+  const uploadedFiles: Map<string, DeploymentFile> = new Map()
   for (const filesKey in ctx.formData.files) {
-    uploadedFiles.set(filesKey, ctx.formData.files[filesKey].value)
+    uploadedFiles.set(filesKey, toDeploymentFile(ctx.formData.files[filesKey]))
   }
 
   const contentHashesInStorage = await ctx.components.storage.existMultiple(

--- a/src/controllers/handlers/index-handler.ts
+++ b/src/controllers/handlers/index-handler.ts
@@ -1,6 +1,11 @@
 import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
-import { getPaginationParams } from '@dcl/http-commons'
+
+// Known consumers (opscli's AB-conversion snapshot, asset-bundle-encoder's download-worlds.sh)
+// fetch /index without pagination and expect every world, so we default to a large page to keep
+// that behavior effectively unchanged while still bounding the (uncached, N+1) query. Callers can
+// page with ?limit/&offset; an explicit limit is clamped to the same maximum.
+export const MAX_INDEX_LIMIT = 10_000
 
 export async function getIndexHandler(
   context: HandlerContextWithPath<'config' | 'worldsIndexer', '/index'>
@@ -9,9 +14,10 @@ export async function getIndexHandler(
 
   const baseUrl = (await config.getString('HTTP_BASE_URL')) || `${context.url.protocol}//${context.url.host}`
 
-  // Bound the amount of data retrieved per request (defaults to a capped page size). Callers
-  // that need the full index can page through it with ?limit/&offset.
-  const { limit, offset } = getPaginationParams(context.url.searchParams)
+  const limitParam = parseInt(context.url.searchParams.get('limit') ?? '', 10)
+  const offsetParam = parseInt(context.url.searchParams.get('offset') ?? '', 10)
+  const limit = !isNaN(limitParam) && limitParam > 0 ? Math.min(limitParam, MAX_INDEX_LIMIT) : MAX_INDEX_LIMIT
+  const offset = !isNaN(offsetParam) && offsetParam >= 0 ? offsetParam : 0
   const indexData = await worldsIndexer.getIndex({ limit, offset })
 
   // Transform to URLs

--- a/src/controllers/handlers/index-handler.ts
+++ b/src/controllers/handlers/index-handler.ts
@@ -1,5 +1,6 @@
 import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { getPaginationParams } from '@dcl/http-commons'
 
 export async function getIndexHandler(
   context: HandlerContextWithPath<'config' | 'worldsIndexer', '/index'>
@@ -8,7 +9,10 @@ export async function getIndexHandler(
 
   const baseUrl = (await config.getString('HTTP_BASE_URL')) || `${context.url.protocol}//${context.url.host}`
 
-  const indexData = await worldsIndexer.getIndex()
+  // Bound the amount of data retrieved per request (defaults to a capped page size). Callers
+  // that need the full index can page through it with ?limit/&offset.
+  const { limit, offset } = getPaginationParams(context.url.searchParams)
+  const indexData = await worldsIndexer.getIndex({ limit, offset })
 
   // Transform to URLs
   for (const worldData of indexData.index) {

--- a/src/controllers/handlers/world-settings-handler.ts
+++ b/src/controllers/handlers/world-settings-handler.ts
@@ -30,8 +30,11 @@ function detectImageFormat(buffer: Buffer): 'png' | 'jpeg' | 'gif' | 'webp' | nu
   if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
     return 'jpeg'
   }
-  // GIF87a / GIF89a
-  if (buffer.length >= 6 && buffer.subarray(0, 4).toString('latin1') === 'GIF8') {
+  // GIF87a / GIF89a (full 6-byte signature, so e.g. "GIF8XX" does not pass)
+  if (
+    buffer.length >= 6 &&
+    (buffer.subarray(0, 6).toString('latin1') === 'GIF87a' || buffer.subarray(0, 6).toString('latin1') === 'GIF89a')
+  ) {
     return 'gif'
   }
   // RIFF....WEBP

--- a/src/controllers/handlers/world-settings-handler.ts
+++ b/src/controllers/handlers/world-settings-handler.ts
@@ -2,7 +2,7 @@ import { HandlerContextWithPath, WorldSettings, WorldSettingsInput } from '../..
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
 import { UnauthorizedError, ValidationError, WorldNotFoundError } from '../../logic/settings'
-import { FormDataContext, isDefinedMultipartField } from '../../logic/multipart'
+import { FormDataContext, isDefinedMultipartField, readUploadedFile } from '../../logic/multipart'
 import { ICoordinatesComponent } from '../../logic/coordinates'
 
 type SnakeCaseWorldSettings = {
@@ -15,6 +15,34 @@ type SnakeCaseWorldSettings = {
   single_player?: boolean
   show_in_places?: boolean
   thumbnail_hash?: string
+}
+
+// Allowed thumbnail image formats, identified by their leading magic bytes. The thumbnail is
+// stored and later served verbatim, so we reject anything that is not a real raster image
+// (e.g. HTML/SVG/scripts smuggled as a "thumbnail").
+function detectImageFormat(buffer: Buffer): 'png' | 'jpeg' | 'gif' | 'webp' | null {
+  if (
+    buffer.length >= 8 &&
+    buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  ) {
+    return 'png'
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'jpeg'
+  }
+  // GIF87a / GIF89a
+  if (buffer.length >= 6 && buffer.subarray(0, 4).toString('latin1') === 'GIF8') {
+    return 'gif'
+  }
+  // RIFF....WEBP
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('latin1') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('latin1') === 'WEBP'
+  ) {
+    return 'webp'
+  }
+  return null
 }
 
 function toSnakeCaseSettings(settings: WorldSettings): SnakeCaseWorldSettings {
@@ -31,10 +59,10 @@ function toSnakeCaseSettings(settings: WorldSettings): SnakeCaseWorldSettings {
   }
 }
 
-function parseMultipartInput(
+async function parseMultipartInput(
   formData: FormDataContext['formData'],
   coordinates: ICoordinatesComponent
-): WorldSettingsInput {
+): Promise<WorldSettingsInput> {
   const { fields, files } = formData
   const input: WorldSettingsInput = {}
 
@@ -109,14 +137,19 @@ function parseMultipartInput(
   }
 
   // Handle thumbnail file
-  if (files.thumbnail?.value) {
+  if (files.thumbnail) {
     const maxThumbnailSize = 1024 * 1024 // 1MB
-    if (files.thumbnail.value.length > maxThumbnailSize) {
+    if (files.thumbnail.size > maxThumbnailSize) {
       throw new ValidationError(
-        `Invalid thumbnail: size ${files.thumbnail.value.length} bytes exceeds maximum of ${maxThumbnailSize} bytes (1MB).`
+        `Invalid thumbnail: size ${files.thumbnail.size} bytes exceeds maximum of ${maxThumbnailSize} bytes (1MB).`
       )
     }
-    input.thumbnail = files.thumbnail.value
+    // Thumbnails are capped at 1MB, so reading the temp file fully into memory is fine.
+    const thumbnail = await readUploadedFile(files.thumbnail)
+    if (!detectImageFormat(thumbnail)) {
+      throw new ValidationError('Invalid thumbnail: expected a PNG, JPEG, GIF or WebP image.')
+    }
+    input.thumbnail = thumbnail
   }
 
   return input
@@ -160,7 +193,7 @@ export async function updateWorldSettingsHandler(
   const signer = ctx.verification!.auth
 
   try {
-    const input = parseMultipartInput(ctx.formData, coordinates)
+    const input = await parseMultipartInput(ctx.formData, coordinates)
     const updatedSettings = await settings.updateWorldSettings(world_name, signer, input)
 
     return {

--- a/src/controllers/handlers/worlds-handler.ts
+++ b/src/controllers/handlers/worlds-handler.ts
@@ -3,6 +3,11 @@ import { InvalidRequestError, getPaginationParams } from '@dcl/http-commons'
 import { EthAddress } from '@dcl/schemas'
 import { HandlerContextWithPath, WorldInfo, WorldsOrderBy, OrderDirection } from '../../types'
 
+// Caps the free-text search term length. The term feeds leading-wildcard ILIKE and pg_trgm
+// similarity over several columns (sequential scans), so an unbounded term lets an anonymous
+// caller drive arbitrarily expensive queries. 64 chars comfortably fits any real world name/title.
+export const MAX_SEARCH_TERM_LENGTH = 64
+
 type SnakeCaseWorldInfo = {
   name: string
   owner: string
@@ -48,13 +53,19 @@ export async function getWorldsHandler(
 
   // Extract optional query parameters
   const deployer = ctx.url.searchParams.get('authorized_deployer') ?? undefined
-  const search = ctx.url.searchParams.get('search') ?? undefined
+  const trimmedSearch = ctx.url.searchParams.get('search')?.trim()
+  const search = trimmedSearch ? trimmedSearch : undefined
   const hasDeployedScenesParam = ctx.url.searchParams.get('has_deployed_scenes')
   const hasDeployedScenes = hasDeployedScenesParam !== null ? hasDeployedScenesParam === 'true' : undefined
 
   // Validate authorized_deployer is a valid Ethereum address if provided
   if (deployer && !EthAddress.validate(deployer)) {
     throw new InvalidRequestError(`Invalid authorized_deployer address: ${deployer}. Must be a valid Ethereum address.`)
+  }
+
+  // Bound the search term length to keep the ILIKE/trigram scan cost predictable
+  if (search !== undefined && search.length > MAX_SEARCH_TERM_LENGTH) {
+    throw new InvalidRequestError(`Invalid search parameter: must be at most ${MAX_SEARCH_TERM_LENGTH} characters.`)
   }
   const sortParam = ctx.url.searchParams.get('sort') ?? WorldsOrderBy.Name
   const orderParam = ctx.url.searchParams.get('order') ?? OrderDirection.Asc

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -55,10 +55,14 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   const router = new Router<GlobalContext>()
   router.use(errorHandler)
 
+  // Aggregate buffered-bytes budget for multipart uploads. Tune per container memory; falls back
+  // to the parser's default when unset.
+  const maxInFlightUploadBytes = await config.getNumber('MAX_IN_FLIGHT_UPLOAD_BYTES')
+
   router.get('/world/:world_name/about', worldAboutHandler)
 
   // Post world scene(s)
-  router.post('/entities', multipartParserWrapper(deployEntity))
+  router.post('/entities', multipartParserWrapper(deployEntity, { maxInFlightUploadBytes }))
   // Undeploy the whole world
   router.delete('/entities/:world_name', signedFetchMiddleware, undeployEntity)
   router.get('/available-content', availableContentHandler)
@@ -75,7 +79,11 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
 
   // World settings
   router.get('/world/:world_name/settings', getWorldSettingsHandler)
-  router.put('/world/:world_name/settings', signedFetchMiddleware, multipartParserWrapper(updateWorldSettingsHandler))
+  router.put(
+    '/world/:world_name/settings',
+    signedFetchMiddleware,
+    multipartParserWrapper(updateWorldSettingsHandler, { maxInFlightUploadBytes })
+  )
 
   // World manifest
   router.get('/world/:world_name/manifest', getWorldManifestHandler)

--- a/src/logic/multipart.ts
+++ b/src/logic/multipart.ts
@@ -3,7 +3,26 @@
 import { InvalidRequestError } from '@dcl/http-commons'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import busboy, { FieldInfo, FileInfo } from 'busboy'
+import { createReadStream, createWriteStream } from 'fs'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { Readable } from 'stream'
+import { DeploymentFile } from '../types'
+
+/**
+ * An uploaded file. The bytes are streamed to a temp file on disk rather than buffered in memory,
+ * so a deployment of large content files never holds them all in RAM at once. Consumers stream
+ * the file from {@link UploadedFile.filepath} (for hashing/storing) or read it fully via
+ * {@link readUploadedFile} (only for small files such as the entity JSON).
+ */
+export type UploadedFile = FileInfo & {
+  fieldname: string
+  /** Absolute path to the temp file holding the uploaded bytes. Removed once the handler returns. */
+  filepath: string
+  /** Number of bytes written to disk. */
+  size: number
+}
 
 export type FormDataContext = IHttpServerComponent.DefaultContext & {
   formData: {
@@ -14,13 +33,22 @@ export type FormDataContext = IHttpServerComponent.DefaultContext & {
         value: string[]
       }
     >
-    files: Record<
-      string,
-      FileInfo & {
-        fieldname: string
-        value: Buffer
-      }
-    >
+    files: Record<string, UploadedFile>
+  }
+}
+
+/** Reads a temp-backed uploaded file fully into memory. Use only for small files. */
+export function readUploadedFile(file: UploadedFile): Promise<Buffer> {
+  return readFile(file.filepath)
+}
+
+/** Wraps an uploaded file as a {@link DeploymentFile}, memoizing the full-buffer read. */
+export function toDeploymentFile(file: UploadedFile): DeploymentFile {
+  let buffered: Promise<Buffer> | undefined
+  return {
+    size: file.size,
+    getStream: () => createReadStream(file.filepath),
+    asBuffer: () => (buffered ??= readFile(file.filepath))
   }
 }
 
@@ -41,11 +69,30 @@ const DEFAULT_LIMITS: busboy.Limits = {
   parts: 10_100
 }
 
+/**
+ * Maximum aggregate bytes that may be in flight (written to temp files) across all concurrent
+ * uploads. The parser on POST /entities runs before any authentication, so without this ceiling
+ * an unauthenticated client could open many concurrent uploads and exhaust resources.
+ *
+ * Uploads are streamed to disk rather than buffered in memory, so the limiting resource is the
+ * container's ephemeral storage (e.g. 20 GB by default on Fargate), not RAM. The 4 GB default
+ * leaves ample headroom while allowing many concurrent uploads; tune it to the available disk via
+ * the MAX_IN_FLIGHT_UPLOAD_BYTES config. A request reserves its declared Content-Length (capped at
+ * the per-request limit; the full limit when none is declared), so small uploads barely count
+ * while large ones are bounded.
+ */
+export const DEFAULT_MAX_IN_FLIGHT_UPLOAD_BYTES = 4 * 1024 * MB
+
+// Module-level so the budget is shared across every route that buffers multipart bodies.
+let inFlightUploadBytes = 0
+
 export type MultipartParserOptions = {
   /** Maximum total bytes (across all files and fields) buffered before the request is rejected. */
   maxSizeInBytes?: number
   /** Overrides for the busboy limits (count/size caps). Defaults to {@link DEFAULT_LIMITS}. */
   limits?: busboy.Limits
+  /** Aggregate buffered-bytes budget across concurrent uploads. Defaults to {@link DEFAULT_MAX_IN_FLIGHT_UPLOAD_BYTES}. */
+  maxInFlightUploadBytes?: number
 }
 
 export function multipartParserWrapper<Ctx extends FormDataContext, T extends IHttpServerComponent.IResponse>(
@@ -53,8 +100,41 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
   options?: MultipartParserOptions
 ): (ctx: IHttpServerComponent.DefaultContext) => Promise<T> {
   const maxSizeInBytes = options?.maxSizeInBytes ?? DEFAULT_MAX_UPLOAD_SIZE_IN_BYTES
+  const maxInFlightUploadBytes = options?.maxInFlightUploadBytes ?? DEFAULT_MAX_IN_FLIGHT_UPLOAD_BYTES
 
   return async function (ctx): Promise<T> {
+    // Reject obviously-oversized uploads up front, before reading or buffering any of the body.
+    // A request that lies about (or omits) Content-Length is still bounded by the streaming
+    // guard further down, which stops buffering once totalBytes exceeds maxSizeInBytes.
+    const declaredSize = parseInt(ctx.request.headers.get('content-length') || '', 10)
+    if (!isNaN(declaredSize) && declaredSize > maxSizeInBytes) {
+      throw new InvalidRequestError('The multipart request is too large.')
+    }
+
+    // Bound aggregate buffered memory: this parser runs before any auth on POST /entities, so it
+    // must self-limit how much it buffers at once. Each request reserves its declared size (capped
+    // at the per-request limit; the full limit when no Content-Length is given). Requests that
+    // would push the in-flight total over budget are shed with 503 without reading the body. We
+    // always admit when nothing else is in flight so a single large upload can still make progress.
+    // The reservation is held until the handler completes, since the buffers live for its duration.
+    const reservedBytes = isNaN(declaredSize) ? maxSizeInBytes : Math.min(declaredSize, maxSizeInBytes)
+    if (inFlightUploadBytes > 0 && inFlightUploadBytes + reservedBytes > maxInFlightUploadBytes) {
+      return {
+        status: 503,
+        headers: { 'Retry-After': '5' },
+        body: { error: 'Service Unavailable', message: 'Server is buffering too many uploads, please retry shortly.' }
+        // The wrapper is typed to the handler's response type; this shed response is a valid IResponse.
+      } as unknown as T
+    }
+    inFlightUploadBytes += reservedBytes
+    try {
+      return await parseAndHandle(ctx)
+    } finally {
+      inFlightUploadBytes -= reservedBytes
+    }
+  }
+
+  async function parseAndHandle(ctx: IHttpServerComponent.DefaultContext): Promise<T> {
     let formDataParser: busboy.Busboy
     try {
       formDataParser = busboy({
@@ -70,12 +150,18 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
     const fields: FormDataContext['formData']['fields'] = {}
     const files: FormDataContext['formData']['files'] = {}
 
+    // Uploaded files are streamed to temp files under this directory and removed once the handler
+    // returns, so large content files are never held in memory in full.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'wcs-upload-'))
+    const fileWrites: Promise<void>[] = []
+    let fileIndex = 0
+
     let totalBytes = 0
     let limitError: string | undefined
     // Record the first limit breach; surfaced after parsing finishes. We do NOT destroy the
     // parser here (destroying busboy mid-write corrupts its internal state) — busboy already
-    // truncates/caps per its limits, and the data handlers below stop buffering once over the
-    // limit, so memory stays bounded while busboy drains and emits 'close'.
+    // truncates/caps per its limits, and the handlers below stop writing once over the limit, so
+    // disk usage stays bounded while busboy drains and emits 'close'.
     function fail(message: string): void {
       if (!limitError) {
         limitError = message
@@ -114,28 +200,58 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
       }
     })
     formDataParser.on('file', function (name: string, stream: Readable, info: FileInfo) {
-      const chunks: any[] = []
+      const filepath = join(tmpDir, String(fileIndex++))
+      const writeStream = createWriteStream(filepath)
+      let size = 0
+      let aborted = false
+
       stream.on('limit', function () {
         fail('An uploaded file exceeds the maximum allowed size.')
       })
-      stream.on('data', function (data) {
-        totalBytes += data.length
-        if (totalBytes > maxSizeInBytes) {
-          fail('The multipart request is too large.')
-          return
+
+      const written = new Promise<void>((resolve) => {
+        const finalize = (): void => {
+          files[name] = { ...info, fieldname: name, filepath, size }
+          resolve()
         }
-        chunks.push(data)
+        stream.on('data', function (data) {
+          totalBytes += data.length
+          if (aborted) {
+            return
+          }
+          if (totalBytes > maxSizeInBytes) {
+            fail('The multipart request is too large.')
+            aborted = true
+            writeStream.end()
+            return
+          }
+          size += data.length
+          // Respect backpressure so a slow disk doesn't let chunks pile up in memory.
+          if (!writeStream.write(data)) {
+            stream.pause()
+            writeStream.once('drain', () => stream.resume())
+          }
+        })
+        stream.on('end', function () {
+          if (!aborted) {
+            writeStream.end()
+          }
+        })
+        stream.on('error', function () {
+          aborted = true
+          writeStream.destroy()
+          finalize()
+        })
+        writeStream.on('finish', finalize)
+        writeStream.on('error', function () {
+          if (!aborted) {
+            fail('Failed to store an uploaded file.')
+            aborted = true
+          }
+          finalize()
+        })
       })
-      stream.on('error', function () {
-        stream.resume()
-      })
-      stream.on('end', function () {
-        files[name] = {
-          ...info,
-          fieldname: name,
-          value: Buffer.concat(chunks)
-        }
-      })
+      fileWrites.push(written)
     })
 
     ctx.request.body.pipe(formDataParser)
@@ -143,16 +259,24 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
     const newContext: Ctx = Object.assign(Object.create(ctx), { formData: { fields, files } })
 
     try {
-      await finished
-    } catch (error: any) {
-      throw new InvalidRequestError(limitError || error.message || 'Invalid multipart form data')
-    }
+      try {
+        await finished
+      } catch (error: any) {
+        throw new InvalidRequestError(limitError || error.message || 'Invalid multipart form data')
+      }
 
-    if (limitError) {
-      throw new InvalidRequestError(limitError)
-    }
+      // Wait for every temp file to finish flushing before the handler reads them.
+      await Promise.all(fileWrites)
 
-    return handler(newContext)
+      if (limitError) {
+        throw new InvalidRequestError(limitError)
+      }
+
+      return await handler(newContext)
+    } finally {
+      // Remove temp files once the handler has finished consuming them (on success or error).
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => undefined)
+    }
   }
 }
 

--- a/src/logic/settings/component.ts
+++ b/src/logic/settings/component.ts
@@ -58,7 +58,9 @@ export async function createSettingsComponent(
     // Handle thumbnail upload
     let thumbnailHash: string | undefined
     if (settings.thumbnail) {
-      // Store new thumbnail by hash (content-addressable, old thumbnails cleaned up by GC)
+      // Store new thumbnail by content hash (content-addressable, old thumbnails cleaned up by GC).
+      // The SHA-256 hex digest is served back through GET /contents/:hashId, which accepts both
+      // CIDv1 and SHA-256 content keys.
       thumbnailHash = createHash('sha256').update(settings.thumbnail).digest('hex')
       await storage.storeStream(thumbnailHash, bufferToStream(settings.thumbnail))
     }

--- a/src/logic/validations/common.ts
+++ b/src/logic/validations/common.ts
@@ -5,14 +5,16 @@ import { AuthChain, Entity, EntityType, EthAddress, IPFSv2 } from '@dcl/schemas'
 import { Authenticator } from '@dcl/crypto'
 
 export const validateEntityId: Validation = async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-  const entityRaw = deployment.files.get(deployment.entity.id)
-  if (!entityRaw) {
+  const entityFile = deployment.files.get(deployment.entity.id)
+  if (!entityFile) {
     return createValidationResult(['Entity not found in files.'])
   }
 
-  const result = (await hashV1(entityRaw)) === deployment.entity.id
+  const actualHash = await hashV1(entityFile.getStream())
   return createValidationResult(
-    !result ? [`Invalid entity hash: expected ${await hashV1(entityRaw)} but got ${deployment.entity.id}`] : []
+    actualHash !== deployment.entity.id
+      ? [`Invalid entity hash: expected ${actualHash} but got ${deployment.entity.id}`]
+      : []
   )
 }
 
@@ -73,8 +75,8 @@ export const validateFiles: Validation = async (deployment: DeploymentToValidate
     if (!IPFSv2.validate(hash)) {
       errors.push(`Only CIDv1 are allowed for content files: ${hash}`)
     }
-    // hash the file
-    if ((await hashV1(deployment.files.get(hash)!)) !== hash) {
+    // hash the file (streamed from disk so large files aren't loaded into memory)
+    if ((await hashV1(deployment.files.get(hash)!.getStream())) !== hash) {
       errors.push(`The hashed file doesn't match the provided content: ${hash}`)
     }
   }

--- a/src/logic/validations/scene.ts
+++ b/src/logic/validations/scene.ts
@@ -1,4 +1,4 @@
-import { DeploymentToValidate, Validation, ValidationResult, ValidatorComponents } from '../../types'
+import { DeploymentFile, DeploymentToValidate, Validation, ValidationResult, ValidatorComponents } from '../../types'
 import { Entity, Scene } from '@dcl/schemas'
 import { createValidationResult, OK } from './utils'
 import { ICoordinatesComponent } from '../coordinates'
@@ -85,7 +85,7 @@ export function createValidateBannedNames(
   components: Pick<ValidatorComponents, 'nameDenyListChecker' | 'worldsManager'>
 ) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
     const worldSpecifiedName = sceneJson.metadata.worldConfiguration.name
 
     // Check the name is not banned
@@ -107,7 +107,7 @@ export function createValidateDeploymentPermission(
   components: Pick<ValidatorComponents, 'coordinates' | 'namePermissionChecker' | 'permissions' | 'worldsManager'>
 ) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
     const worldSpecifiedName = sceneJson.metadata.worldConfiguration.name
     const signer = deployment.authChain[0].payload
     const parcels = getDeploymentParcels(deployment, components.coordinates)
@@ -137,7 +137,7 @@ export function createValidateDeploymentPermission(
 /** Rejects scenes that occupy more parcels than the world's configured maximum. */
 export function createValidateSceneDimensions(components: Pick<ValidatorComponents, 'coordinates' | 'limitsManager'>) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
     const worldName = sceneJson.metadata.worldConfiguration.name
 
     const maxParcels = await components.limitsManager.getMaxAllowedParcelsFor(worldName || '')
@@ -196,12 +196,12 @@ export function createValidateSize(components: Pick<ValidatorComponents, 'coordi
       return content.size || 0
     }
 
-    const calculateDeploymentSize = async (entity: Entity, files: Map<string, Uint8Array>): Promise<number> => {
+    const calculateDeploymentSize = async (entity: Entity, files: Map<string, DeploymentFile>): Promise<number> => {
       let totalSize = 0
       for (const hash of new Set(entity.content?.map((item) => item.hash) ?? [])) {
         const uploadedFile = files.get(hash)
         if (uploadedFile) {
-          totalSize += uploadedFile.byteLength
+          totalSize += uploadedFile.size
         } else {
           const contentSize = await fetchContentFileSize(hash)
           totalSize += contentSize
@@ -210,7 +210,7 @@ export function createValidateSize(components: Pick<ValidatorComponents, 'coordi
       return totalSize
     }
 
-    const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
     const worldName = sceneJson.metadata.worldConfiguration.name
     // Pass the deployment's parcels so the quota credits back only the scenes this
     // deployment actually replaces (those overlapping these parcels), not the whole world.
@@ -237,7 +237,7 @@ export function createValidateSize(components: Pick<ValidatorComponents, 'coordi
 
 export function createValidateSdkVersion(components: Pick<ValidatorComponents, 'limitsManager' | 'storage'>) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
     const worldName = sceneJson.metadata.worldConfiguration.name
     const allowSdk6 = await components.limitsManager.getAllowSdk6For(worldName || '')
 
@@ -255,7 +255,7 @@ export function createValidateSdkVersion(components: Pick<ValidatorComponents, '
 export const validateMiniMapImages: Validation = async (
   deployment: DeploymentToValidate
 ): Promise<ValidationResult> => {
-  const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+  const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
 
   const errors: string[] = []
 
@@ -290,7 +290,7 @@ export const validateThumbnail: Validation = async (deployment: DeploymentToVali
 export const validateSkyboxTextures: Validation = async (
   deployment: DeploymentToValidate
 ): Promise<ValidationResult> => {
-  const sceneJson = JSON.parse(deployment.files.get(deployment.entity.id)!.toString())
+  const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
 
   const errors: string[] = []
 

--- a/src/logic/validations/scene.ts
+++ b/src/logic/validations/scene.ts
@@ -85,8 +85,7 @@ export function createValidateBannedNames(
   components: Pick<ValidatorComponents, 'nameDenyListChecker' | 'worldsManager'>
 ) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-    const worldSpecifiedName = sceneJson.metadata.worldConfiguration.name
+    const worldSpecifiedName = deployment.entity.metadata.worldConfiguration.name
 
     // Check the name is not banned
     if (await components.nameDenyListChecker.checkNameDenyList(worldSpecifiedName)) {
@@ -107,8 +106,7 @@ export function createValidateDeploymentPermission(
   components: Pick<ValidatorComponents, 'coordinates' | 'namePermissionChecker' | 'permissions' | 'worldsManager'>
 ) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-    const worldSpecifiedName = sceneJson.metadata.worldConfiguration.name
+    const worldSpecifiedName = deployment.entity.metadata.worldConfiguration.name
     const signer = deployment.authChain[0].payload
     const parcels = getDeploymentParcels(deployment, components.coordinates)
 
@@ -137,8 +135,7 @@ export function createValidateDeploymentPermission(
 /** Rejects scenes that occupy more parcels than the world's configured maximum. */
 export function createValidateSceneDimensions(components: Pick<ValidatorComponents, 'coordinates' | 'limitsManager'>) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-    const worldName = sceneJson.metadata.worldConfiguration.name
+    const worldName = deployment.entity.metadata.worldConfiguration.name
 
     const maxParcels = await components.limitsManager.getMaxAllowedParcelsFor(worldName || '')
     if (getDeploymentParcels(deployment, components.coordinates).length > maxParcels) {
@@ -210,8 +207,7 @@ export function createValidateSize(components: Pick<ValidatorComponents, 'coordi
       return totalSize
     }
 
-    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-    const worldName = sceneJson.metadata.worldConfiguration.name
+    const worldName = deployment.entity.metadata.worldConfiguration.name
     // Pass the deployment's parcels so the quota credits back only the scenes this
     // deployment actually replaces (those overlapping these parcels), not the whole world.
     const maxTotalSizeInBytes = await components.limitsManager.getMaxAllowedSizeInBytesFor(
@@ -237,8 +233,7 @@ export function createValidateSize(components: Pick<ValidatorComponents, 'coordi
 
 export function createValidateSdkVersion(components: Pick<ValidatorComponents, 'limitsManager' | 'storage'>) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-    const worldName = sceneJson.metadata.worldConfiguration.name
+    const worldName = deployment.entity.metadata.worldConfiguration.name
     const allowSdk6 = await components.limitsManager.getAllowSdk6For(worldName || '')
 
     const sdkVersion = deployment.entity.metadata.runtimeVersion
@@ -255,16 +250,15 @@ export function createValidateSdkVersion(components: Pick<ValidatorComponents, '
 export const validateMiniMapImages: Validation = async (
   deployment: DeploymentToValidate
 ): Promise<ValidationResult> => {
-  const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-
   const errors: string[] = []
+  const content = deployment.entity.content || []
 
   for (const imageFile of [
-    sceneJson.metadata.worldConfiguration?.miniMapConfig?.dataImage,
-    sceneJson.metadata.worldConfiguration?.miniMapConfig?.estateImage
+    deployment.entity.metadata.worldConfiguration?.miniMapConfig?.dataImage,
+    deployment.entity.metadata.worldConfiguration?.miniMapConfig?.estateImage
   ]) {
     if (imageFile) {
-      const isFilePresent = sceneJson.content.some((content: ContentMapping) => content.file === imageFile)
+      const isFilePresent = content.some((mapping: ContentMapping) => mapping.file === imageFile)
       if (!isFilePresent) {
         errors.push(`The file ${imageFile} is not present in the entity.`)
       }
@@ -290,13 +284,12 @@ export const validateThumbnail: Validation = async (deployment: DeploymentToVali
 export const validateSkyboxTextures: Validation = async (
   deployment: DeploymentToValidate
 ): Promise<ValidationResult> => {
-  const sceneJson = JSON.parse((await deployment.files.get(deployment.entity.id)!.asBuffer()).toString())
-
   const errors: string[] = []
+  const content = deployment.entity.content || []
 
-  for (const textureFile of sceneJson.metadata.worldConfiguration?.skyboxConfig?.textures || []) {
+  for (const textureFile of deployment.entity.metadata.worldConfiguration?.skyboxConfig?.textures || []) {
     if (textureFile) {
-      const isFilePresent = sceneJson.content.some((content: ContentMapping) => content.file === textureFile)
+      const isFilePresent = content.some((mapping: ContentMapping) => mapping.file === textureFile)
       if (!isFilePresent) {
         errors.push(`The texture file ${textureFile} is not present in the entity.`)
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import { HTTPProvider } from 'eth-connect'
 import { ISubgraphComponent } from '@well-known-components/thegraph-component'
 import { IStatusComponent } from './adapters/status'
 import { AuthChain, AuthLink, Entity, EthAddress, IPFSv2 } from '@dcl/schemas'
+import { Readable } from 'stream'
 import { MigrationExecutor } from './adapters/migration-executor'
 import { IPgComponent } from '@dcl/pg-component'
 import { AuthIdentity } from '@dcl/crypto'
@@ -56,9 +57,23 @@ export type Migration = {
   run: (components: MigratorComponents) => Promise<void>
 }
 
+/**
+ * A file uploaded as part of a deployment. Backed by a temp file on disk so large content files
+ * are never held in memory in full: callers stream them for hashing/storing and only read the
+ * small entity JSON into a Buffer.
+ */
+export type DeploymentFile = {
+  /** Size in bytes of the uploaded file. */
+  size: number
+  /** Opens a fresh read stream over the file's bytes (for hashing and storing). */
+  getStream(): Readable
+  /** Reads the full file into a Buffer. Intended for small files such as the entity JSON. */
+  asBuffer(): Promise<Buffer>
+}
+
 export type DeploymentToValidate = {
   entity: Entity
-  files: Map<string, Uint8Array>
+  files: Map<string, DeploymentFile>
   authChain: AuthChain
   contentHashesInStorage: Map<string, boolean>
 }
@@ -456,7 +471,7 @@ export type WorldsIndex = {
 }
 
 export type IWorldsIndexer = {
-  getIndex(): Promise<WorldsIndex>
+  getIndex(options?: GetRawWorldRecordsOptions): Promise<WorldsIndex>
 }
 
 export type DeploymentResult = {
@@ -468,7 +483,7 @@ export type IEntityDeployer = {
     baseUrl: string,
     entity: Entity,
     allContentHashesInStorage: Map<string, boolean>,
-    files: Map<string, Uint8Array>,
+    files: Map<string, DeploymentFile>,
     entityJson: string,
     authChain: AuthLink[]
   ): Promise<DeploymentResult>

--- a/test/integration/index-handler.spec.ts
+++ b/test/integration/index-handler.spec.ts
@@ -85,4 +85,23 @@ test('index handler GET /index', function ({ components }) {
     })
     expect(world2Data.scenes[0].thumbnail).toBeUndefined()
   })
+
+  it('returns the full index by default and honors explicit limit/offset', async () => {
+    const { localFetch, worldCreator } = components
+
+    await worldCreator.createWorldWithScene()
+    await worldCreator.createWorldWithScene()
+
+    // No pagination params: returns every world (backward compatible for consumers like the
+    // AB-conversion snapshot job that expect the full set).
+    const all = (await (await localFetch.fetch('/index')).json()).data
+    expect(all.length).toBeGreaterThanOrEqual(2)
+
+    // Explicit limit/offset paginate over the same ordering.
+    const firstPage = (await (await localFetch.fetch('/index?limit=1&offset=0')).json()).data
+    const secondPage = (await (await localFetch.fetch('/index?limit=1&offset=1')).json()).data
+    expect(firstPage).toHaveLength(1)
+    expect(secondPage).toHaveLength(1)
+    expect(secondPage[0].name).not.toBe(firstPage[0].name)
+  })
 })

--- a/test/integration/world-settings-handler.spec.ts
+++ b/test/integration/world-settings-handler.spec.ts
@@ -213,6 +213,43 @@ test('WorldSettingsHandler', ({ components, stubComponents }) => {
       })
     })
 
+    describe('and the thumbnail starts with GIF8 but is not a real GIF signature', () => {
+      let identity: Identity
+      let worldName: string
+
+      beforeEach(async () => {
+        const { worldCreator } = components
+
+        identity = await getIdentity()
+        const created = await worldCreator.createWorldWithScene({ owner: identity.authChain })
+        worldName = created.worldName
+
+        stubComponents.namePermissionChecker.checkPermission
+          .withArgs(identity.authChain.authChain[0].payload.toLowerCase(), worldName)
+          .resolves(true)
+      })
+
+      it('should respond with a 400 (the full 6-byte GIF87a/GIF89a signature is required)', async () => {
+        const { localFetch } = components
+
+        // "GIF8XX" passes a 4-byte "GIF8" check but is not a real GIF signature.
+        const fakeGif = Buffer.concat([Buffer.from('GIF8XX', 'latin1'), Buffer.alloc(16, 0)])
+
+        const response = await makeSignedMultipartRequest(
+          localFetch,
+          `/world/${worldName}/settings`,
+          identity,
+          {},
+          { thumbnail: { buffer: fakeGif, filename: 'thumbnail.gif' } }
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.json()).toMatchObject({
+          error: 'Invalid thumbnail: expected a PNG, JPEG, GIF or WebP image.'
+        })
+      })
+    })
+
     describe('and the thumbnail is a valid PNG image', () => {
       let identity: Identity
       let worldName: string

--- a/test/integration/world-settings-handler.spec.ts
+++ b/test/integration/world-settings-handler.spec.ts
@@ -177,6 +177,84 @@ test('WorldSettingsHandler', ({ components, stubComponents }) => {
       })
     })
 
+    describe('and the thumbnail is not a valid image', () => {
+      let identity: Identity
+      let worldName: string
+
+      beforeEach(async () => {
+        const { worldCreator } = components
+
+        identity = await getIdentity()
+        const created = await worldCreator.createWorldWithScene({ owner: identity.authChain })
+        worldName = created.worldName
+
+        stubComponents.namePermissionChecker.checkPermission
+          .withArgs(identity.authChain.authChain[0].payload.toLowerCase(), worldName)
+          .resolves(true)
+      })
+
+      it('should respond with a 400 and reject the non-image thumbnail', async () => {
+        const { localFetch } = components
+
+        const notAnImage = Buffer.from('<html><script>alert(1)</script></html>')
+
+        const response = await makeSignedMultipartRequest(
+          localFetch,
+          `/world/${worldName}/settings`,
+          identity,
+          {},
+          { thumbnail: { buffer: notAnImage, filename: 'thumbnail.png' } }
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.json()).toMatchObject({
+          error: 'Invalid thumbnail: expected a PNG, JPEG, GIF or WebP image.'
+        })
+      })
+    })
+
+    describe('and the thumbnail is a valid PNG image', () => {
+      let identity: Identity
+      let worldName: string
+
+      beforeEach(async () => {
+        const { worldCreator } = components
+
+        identity = await getIdentity()
+        const created = await worldCreator.createWorldWithScene({ owner: identity.authChain })
+        worldName = created.worldName
+
+        stubComponents.namePermissionChecker.checkPermission
+          .withArgs(identity.authChain.authChain[0].payload.toLowerCase(), worldName)
+          .resolves(true)
+      })
+
+      it('should store the thumbnail under a key that is retrievable via GET /contents', async () => {
+        const { localFetch } = components
+
+        const pngBuffer = Buffer.concat([
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), // PNG magic bytes
+          Buffer.from('minimal-png-body')
+        ])
+
+        const response = await makeSignedMultipartRequest(
+          localFetch,
+          `/world/${worldName}/settings`,
+          identity,
+          {},
+          { thumbnail: { buffer: pngBuffer, filename: 'thumbnail.png' } }
+        )
+
+        expect(response.status).toBe(200)
+        const thumbnailHash = (await response.json()).settings.thumbnail_hash
+        // Thumbnails are keyed by SHA-256 hex digest, which GET /contents/:hashId now accepts
+        expect(thumbnailHash).toMatch(/^[0-9a-f]{64}$/)
+
+        const thumbnailResponse = await localFetch.fetch(`/contents/${thumbnailHash}`)
+        expect(thumbnailResponse.status).toBe(200)
+      })
+    })
+
     describe('when the user sends null for categories to clear them', () => {
       let identity: Identity
       let worldName: string

--- a/test/integration/worlds-handler.spec.ts
+++ b/test/integration/worlds-handler.spec.ts
@@ -374,6 +374,20 @@ test('WorldsHandler GET /worlds', function ({ components }) {
           expect(body.worlds[0].name).toBe(worldName3)
         })
       })
+
+      describe('and the search term exceeds the maximum allowed length', function () {
+        it('should respond with a 400 and reject the request', async () => {
+          const { localFetch } = components
+
+          const response = await localFetch.fetch(`/worlds?search=${'a'.repeat(65)}`)
+
+          expect(response.status).toBe(400)
+          expect(await response.json()).toMatchObject({
+            error: 'Bad request',
+            message: 'Invalid search parameter: must be at most 64 characters.'
+          })
+        })
+      })
     })
 
     describe('and authorized_deployer filter is provided', function () {

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -202,16 +202,18 @@ describe('getContentFile', () => {
 
   function createContext(
     storage: Partial<IContentStorageComponent>,
-    rangeHeader?: string
+    rangeHeader?: string,
+    keyOverride?: string
   ): HandlerContextWithPath<'storage', '/contents/:hashId'> {
     const headers = new Headers()
     if (rangeHeader) {
       headers.set('range', rangeHeader)
     }
 
+    const key = keyOverride ?? hashId
     return {
-      url: new URL(`http://localhost/contents/${hashId}`),
-      params: { hashId },
+      url: new URL(`http://localhost/contents/${key}`),
+      params: { hashId: key },
       request: { headers } as unknown as IHttpServerComponent.IRequest,
       components: { storage: storage as IContentStorageComponent }
     }
@@ -404,6 +406,50 @@ describe('getContentFile', () => {
 
     it('should not call fileInfo', () => {
       expect(storageMock.fileInfo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the content key is a SHA-256 hex digest', () => {
+    const sha256Key = 'a'.repeat(64)
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      const item = createContentItem()
+      storageMock = {
+        fileInfo: jest.fn(),
+        retrieve: jest.fn().mockResolvedValue(item)
+      }
+      response = await getContentFile(createContext(storageMock, undefined, sha256Key))
+    })
+
+    it('should respond with 200', () => {
+      expect(response.status).toEqual(200)
+    })
+
+    it('should retrieve the file by its SHA-256 key', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(sha256Key)
+    })
+  })
+
+  describe('when the content key is neither a CIDv1 nor a SHA-256 digest', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      storageMock = {
+        fileInfo: jest.fn(),
+        retrieve: jest.fn()
+      }
+      response = await getContentFile(createContext(storageMock, undefined, 'not-a-valid-key'))
+    })
+
+    it('should respond with 400', () => {
+      expect(response.status).toEqual(400)
+    })
+
+    it('should not call retrieve', () => {
+      expect(storageMock.retrieve).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/unit/multipart.spec.ts
+++ b/test/unit/multipart.spec.ts
@@ -1,12 +1,16 @@
 import { Readable } from 'stream'
 import FormData from 'form-data'
-import { multipartParserWrapper } from '../../src/logic/multipart'
+import { multipartParserWrapper, readUploadedFile } from '../../src/logic/multipart'
 
-function createMultipartContext(form: FormData): any {
+function createMultipartContext(form: FormData, overrides?: { contentLength?: string }): any {
+  const headers: Record<string, string | null> = {
+    'content-type': form.getHeaders()['content-type'],
+    'content-length': overrides?.contentLength ?? null
+  }
   return {
     request: {
       headers: {
-        get: (name: string) => (name.toLowerCase() === 'content-type' ? form.getHeaders()['content-type'] : null)
+        get: (name: string) => headers[name.toLowerCase()] ?? null
       },
       body: Readable.from(form.getBuffer())
     }
@@ -103,6 +107,117 @@ describe('multipartParserWrapper', function () {
 
     it('should invoke the handler', async () => {
       await parse(context)
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when a file is uploaded within the limits', () => {
+    let parse: (ctx: any) => Promise<any>
+    let context: any
+    let captured: { size: number; contents: string } | undefined
+
+    beforeEach(() => {
+      captured = undefined
+      // Read the temp-backed file inside the handler, before the wrapper cleans it up.
+      const handler = jest.fn(async (ctx: any) => {
+        const file = ctx.formData.files['file']
+        captured = { size: file.size, contents: (await readUploadedFile(file)).toString() }
+        return { status: 200 }
+      })
+      parse = multipartParserWrapper(handler, { maxSizeInBytes: 100000 })
+      const form = new FormData()
+      form.append('file', Buffer.from('hello world'), { filename: 'ok.bin' })
+      context = createMultipartContext(form)
+    })
+
+    it('should expose the number of bytes written to disk', async () => {
+      await parse(context)
+      expect(captured?.size).toBe('hello world'.length)
+    })
+
+    it('should stream the uploaded contents to a readable temp file', async () => {
+      await parse(context)
+      expect(captured?.contents).toBe('hello world')
+    })
+  })
+
+  describe('when the Content-Length header exceeds the maximum allowed size', () => {
+    let handler: jest.Mock
+    let parse: (ctx: any) => Promise<any>
+    let context: any
+
+    beforeEach(() => {
+      handler = jest.fn(async () => ({ status: 200 }))
+      parse = multipartParserWrapper(handler, { maxSizeInBytes: 100 })
+      const form = new FormData()
+      form.append('file', Buffer.alloc(10), { filename: 'small.bin' })
+      context = createMultipartContext(form, { contentLength: '5000' })
+    })
+
+    it('should reject the request before reading the body', async () => {
+      await expect(parse(context)).rejects.toThrow('The multipart request is too large.')
+    })
+
+    it('should not invoke the handler', async () => {
+      await parse(context).catch(() => undefined)
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when concurrent uploads would exceed the buffered-bytes budget', () => {
+    let handler: jest.Mock
+    let parse: (ctx: any) => Promise<any>
+    let releaseFirstUpload: () => void
+    let firstUploadInHandler: Promise<void>
+    let firstUpload: Promise<any>
+
+    beforeEach(async () => {
+      let signalFirstInHandler: () => void
+      firstUploadInHandler = new Promise<void>((resolve) => {
+        signalFirstInHandler = resolve
+      })
+      const gate = new Promise<void>((resolve) => {
+        releaseFirstUpload = resolve
+      })
+
+      handler = jest.fn(async () => {
+        signalFirstInHandler()
+        await gate
+        return { status: 200 }
+      })
+      // With no Content-Length, each request reserves the full per-request limit, so a single
+      // in-flight upload exhausts a budget equal to that limit.
+      parse = multipartParserWrapper(handler, { maxInFlightUploadBytes: 100, maxSizeInBytes: 100 })
+
+      const firstForm = new FormData()
+      firstForm.append('file', Buffer.alloc(10), { filename: 'a.bin' })
+
+      // Hold the single slot busy inside the handler until we release it.
+      firstUpload = parse(createMultipartContext(firstForm))
+      await firstUploadInHandler
+    })
+
+    afterEach(async () => {
+      releaseFirstUpload()
+      await firstUpload
+    })
+
+    it('should shed the extra upload with a 503 response', async () => {
+      const secondForm = new FormData()
+      secondForm.append('file', Buffer.alloc(10), { filename: 'b.bin' })
+
+      const response = await parse(createMultipartContext(secondForm))
+
+      expect(response.status).toBe(503)
+    })
+
+    it('should not invoke the handler for the shed upload', async () => {
+      const secondForm = new FormData()
+      secondForm.append('file', Buffer.alloc(10), { filename: 'b.bin' })
+
+      await parse(createMultipartContext(secondForm))
+
+      // Only the first (still-pending) upload reached the handler.
       expect(handler).toHaveBeenCalledTimes(1)
     })
   })

--- a/test/unit/validations/common.spec.ts
+++ b/test/unit/validations/common.spec.ts
@@ -16,7 +16,7 @@ import {
   validateSigner,
   validateSupportedEntityType
 } from '../../../src/logic/validations/common'
-import { createSceneDeployment } from './shared'
+import { bufferToDeploymentFile, createSceneDeployment } from './shared'
 
 describe('common validations', function () {
   let config: IConfigComponent
@@ -57,7 +57,7 @@ describe('common validations', function () {
       const deployment = await createSceneDeployment(identity.authChain)
 
       // make the entity id invalid
-      deployment.files.set(deployment.entity.id, Buffer.from(stringToUtf8Bytes('invalid')))
+      deployment.files.set(deployment.entity.id, bufferToDeploymentFile(Buffer.from(stringToUtf8Bytes('invalid'))))
 
       const result = await validateEntityId(deployment)
       expect(result.ok()).toBeFalsy()
@@ -212,8 +212,8 @@ describe('common validations', function () {
       const deployment = await createSceneDeployment(identity.authChain)
 
       // Alter the files to make it fail
-      deployment.files.set(await hashV1(Buffer.from('efg')), Buffer.from('efg'))
-      deployment.files.set(await hashV0(Buffer.from('igh')), Buffer.from('igh'))
+      deployment.files.set(await hashV1(Buffer.from('efg')), bufferToDeploymentFile(Buffer.from('efg')))
+      deployment.files.set(await hashV0(Buffer.from('igh')), bufferToDeploymentFile(Buffer.from('igh')))
       deployment.entity.content.push({
         file: 'def.txt',
         hash: 'bafkreie3yaomoex7orli7fumfwgk5abgels5o5fiauxfijzlzoiymqppdi'

--- a/test/unit/validations/shared.ts
+++ b/test/unit/validations/shared.ts
@@ -4,7 +4,18 @@ import { hashV1 } from '@dcl/hashing'
 import { EntityType } from '@dcl/schemas'
 import { DeploymentBuilder } from 'dcl-catalyst-client'
 import { TextDecoder } from 'util'
-import { DeploymentToValidate } from '../../../src/types'
+import { Readable } from 'stream'
+import { DeploymentFile, DeploymentToValidate } from '../../../src/types'
+
+/** Wraps an in-memory buffer as a DeploymentFile for unit tests (no temp files needed). */
+export function bufferToDeploymentFile(content: Uint8Array): DeploymentFile {
+  const buffer = Buffer.from(content)
+  return {
+    size: buffer.byteLength,
+    getStream: () => Readable.from(buffer),
+    asBuffer: async () => buffer
+  }
+}
 
 export async function createSceneDeployment(identityAuthChain: AuthIdentity, entity?: any) {
   const entityFiles = new Map<string, Uint8Array>()
@@ -29,8 +40,8 @@ export async function createSceneDeployment(identityAuthChain: AuthIdentity, ent
     },
     files: entityFiles
   }
-  const { files, entityId } = await DeploymentBuilder.buildEntity(sceneJson)
-  files.set(entityId, Buffer.from(files.get(entityId)!))
+  const { files: builtFiles, entityId } = await DeploymentBuilder.buildEntity(sceneJson)
+  builtFiles.set(entityId, Buffer.from(builtFiles.get(entityId)!))
 
   const authChain = Authenticator.signPayload(identityAuthChain, entityId)
 
@@ -39,7 +50,12 @@ export async function createSceneDeployment(identityAuthChain: AuthIdentity, ent
 
   const finalEntity = {
     id: entityId,
-    ...JSON.parse(new TextDecoder().decode(files.get(entityId)))
+    ...JSON.parse(new TextDecoder().decode(builtFiles.get(entityId)))
+  }
+
+  const files = new Map<string, DeploymentFile>()
+  for (const [name, content] of builtFiles) {
+    files.set(name, bufferToDeploymentFile(content))
   }
 
   const deployment: DeploymentToValidate = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-crypto/sha256-js@^5.2.0", "@aws-crypto/sha256-js@5.2.0":
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz"
   integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
@@ -511,7 +511,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -799,10 +799,10 @@
   resolved "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.4.2.tgz"
   integrity sha512-gJZo3IB8U+jhBJWR0DgoLS+zaUDIb/u79e7Rp+MEM78uH3bvC19S3Dd8lxWEbPXNKlCB0saUptfK/Buw0c1y2Q==
 
-"@dcl/catalyst-storage@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/@dcl/catalyst-storage/-/catalyst-storage-4.5.1.tgz"
-  integrity sha512-hjZbkQIpaA1a0K1m7Q0l4kR49GxDZ+H7sl1m+Hx3qP9wVP0sZVMf4vMzuasww2gtUwJI1PKnW8fkY5wKWuxljA==
+"@dcl/catalyst-storage@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-storage/-/catalyst-storage-4.6.1.tgz#0f169d8d85f6b4c2f5f716399cf6c624b388a7ad"
+  integrity sha512-bz0djW6xhj45DBCRB8RaYphrJSgwJpknOcM/3UPcpba2Wj8pYzsSQEG/mzzKskRWaph4TV1pBS3NSAfcc8Iw0Q==
   dependencies:
     "@well-known-components/interfaces" "^1.1.1"
     aws-sdk "^2.1426.0"
@@ -939,16 +939,6 @@
     ajv "^8.17.1"
     ajv-formats "^3.0.1"
 
-"@dcl/schemas@*", "@dcl/schemas@^26.1.0":
-  version "26.1.0"
-  resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.1.0.tgz"
-  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
-    mitt "^3.0.1"
-
 "@dcl/schemas@^18.0.0":
   version "18.8.0"
   resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-18.8.0.tgz"
@@ -963,6 +953,16 @@
   version "23.1.0"
   resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-23.1.0.tgz"
   integrity sha512-2+Sp4OrUKyGxEe1nLMuLtEmNwLThGUDei0QqXzurkQMkhQdJvB1viS4UW86Wia7AelmCzBewSLU6to8CgQ8UEw==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
+
+"@dcl/schemas@^26.1.0":
+  version "26.1.0"
+  resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.1.0.tgz"
+  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
@@ -995,6 +995,28 @@
     "@aws-sdk/client-sqs" "^3.956.0"
     "@dcl/core-commons" "0.6.0"
     "@well-known-components/interfaces" "^1.5.2"
+
+"@emnapi/core@^1.4.3":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.0.tgz#8a655042dbbb10d0266670c9903c34a7001c705b"
+  integrity sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.2"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.0.tgz#ce16b3674ff7266bbf50f9668bde8a04f3014d4e"
+  integrity sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz#4c93becf5bfa3b13d1bbdcc06aee38321ad8139a"
+  integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
+  dependencies:
+    tslib "^2.4.0"
 
 "@emotion/is-prop-valid@1.4.0":
   version "1.4.0"
@@ -1264,7 +1286,7 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@^29.7.0":
+"@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
   integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
@@ -1285,7 +1307,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
+"@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -1323,14 +1345,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -1338,6 +1352,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jsep-plugin/assignment@^1.3.0":
   version "1.3.0"
@@ -1356,20 +1378,29 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
-"@noble/hashes@~1.2.0", "@noble/hashes@1.2.0":
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
+
+"@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
-
-"@noble/secp256k1@~1.7.0":
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz"
-  integrity sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==
 
 "@noble/secp256k1@1.7.1":
   version "1.7.1"
   resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
+
+"@noble/secp256k1@~1.7.0":
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz"
+  integrity sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1379,7 +1410,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1404,7 +1435,7 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.4.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0", "@opentelemetry/api@>=1.4.0 <1.10.0", "@opentelemetry/api@1.9.0":
+"@opentelemetry/api@1.9.0", "@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.4.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -1581,7 +1612,7 @@
   resolved "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz"
   integrity sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==
 
-"@redis/client@^5.10.0", "@redis/client@5.10.0":
+"@redis/client@5.10.0":
   version "5.10.0"
   resolved "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz"
   integrity sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==
@@ -1603,16 +1634,6 @@
   resolved "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz"
   integrity sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==
 
-"@redocly/ajv@^8.11.2":
-  version "8.17.3"
-  resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.3.tgz"
-  integrity sha512-NQsbJbB/GV7JVO88ebFkMndrnuGp/dTm5/2NISeg+JGcLzTfGBJZ01+V5zD8nKBOpi/dLLNFT+Ql6IcUk8ehng==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
 "@redocly/ajv@8.11.2":
   version "8.11.2"
   resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz"
@@ -1622,6 +1643,16 @@
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js-replace "^1.0.1"
+
+"@redocly/ajv@^8.11.2":
+  version "8.17.3"
+  resolved "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.3.tgz"
+  integrity sha512-NQsbJbB/GV7JVO88ebFkMndrnuGp/dTm5/2NISeg+JGcLzTfGBJZ01+V5zD8nKBOpi/dLLNFT+Ql6IcUk8ehng==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 "@redocly/cli@^1.25.14":
   version "1.34.6"
@@ -1660,7 +1691,7 @@
   resolved "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz"
   integrity sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==
 
-"@redocly/openapi-core@^1.4.0", "@redocly/openapi-core@1.34.6":
+"@redocly/openapi-core@1.34.6", "@redocly/openapi-core@^1.4.0":
   version "1.34.6"
   resolved "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.6.tgz"
   integrity sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==
@@ -1734,6 +1765,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sinonjs/fake-timers@11.2.2":
+  version "11.2.2"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz"
+  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+
 "@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
   version "10.3.0"
   resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz"
@@ -1754,13 +1792,6 @@
   integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-
-"@sinonjs/fake-timers@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz"
-  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
 
 "@sinonjs/samsam@^8.0.0":
   version "8.0.3"
@@ -2220,6 +2251,13 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@tybys/wasm-util@^0.10.0":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"
@@ -2331,6 +2369,13 @@
   dependencies:
     undici-types "~7.16.0"
 
+"@types/node@>=13.7.0":
+  version "25.2.3"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz"
+  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
+  dependencies:
+    undici-types "~7.16.0"
+
 "@types/node@^20.3.1":
   version "20.19.33"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz"
@@ -2344,13 +2389,6 @@
   integrity sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==
   dependencies:
     undici-types "~6.21.0"
-
-"@types/node@>=13.7.0":
-  version "25.2.3"
-  resolved "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz"
-  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
-  dependencies:
-    undici-types "~7.16.0"
 
 "@types/semver@^7.5.0":
   version "7.7.1"
@@ -2420,7 +2458,7 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/parser@^6.0.0 || ^6.0.0-alpha", "@typescript-eslint/parser@^6.21.0":
+"@typescript-eslint/parser@^6.21.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz"
   integrity sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==
@@ -2494,10 +2532,102 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 "@well-known-components/env-config-provider@^1.2.0":
   version "1.2.0"
@@ -2528,7 +2658,7 @@
     on-finished "^2.4.1"
     path-to-regexp "^6.2.1"
 
-"@well-known-components/interfaces@^1.0.0", "@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.4.2", "@well-known-components/interfaces@^1.4.3", "@well-known-components/interfaces@^1.5.2":
+"@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.4.2", "@well-known-components/interfaces@^1.4.3", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz"
   integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
@@ -2605,7 +2735,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
+acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2644,7 +2774,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.11.0, ajv@^8.17.1, ajv@^8.8.2, "ajv@4.11.8 - 8":
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.17.1:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -2745,7 +2875,7 @@ aws-sdk@^2.1426.0, aws-sdk@^2.1545.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@^29.7.0:
+babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -2778,17 +2908,6 @@ babel-plugin-jest-hoist@^29.6.3:
     "@babel/types" "^7.3.3"
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
-
-"babel-plugin-module-resolver@^3.0.0 || ^4.0.0 || ^5.0.0":
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.3.tgz"
-  integrity sha512-h8h6H71ZvdLJZxZrYkaeR30BojTaV7O9GfqacY14SNj5CNB8ocL9tydNzTC0JrnNN7vY3eJhwCmkDj7tuEUaqQ==
-  dependencies:
-    find-babel-config "^2.1.1"
-    glob "^9.3.3"
-    pkg-up "^3.1.0"
-    reselect "^4.1.7"
-    resolve "^1.22.8"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.2.0"
@@ -2902,7 +3021,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -3166,7 +3285,7 @@ cookie@^0.7.2:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-core-js@^3.1.4, core-js@^3.32.1:
+core-js@^3.32.1:
   version "3.48.0"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz"
   integrity sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==
@@ -3246,19 +3365,19 @@ dcl-catalyst-client@^21.8.0:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"
 
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 decko@^1.2.0:
   version "1.2.0"
@@ -3363,15 +3482,15 @@ dompurify@^3.2.4:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dotenv@^16.0.1:
-  version "16.6.1"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
-  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
-
 dotenv@16.4.7:
   version "16.4.7"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+
+dotenv@^16.0.1:
+  version "16.6.1"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -3456,7 +3575,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-prettier@^9.1.0, "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
+eslint-config-prettier@^9.1.0:
   version "9.1.2"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz"
   integrity sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==
@@ -3514,7 +3633,7 @@ eslint-plugin-css-import-order@^1.1.0:
   resolved "https://registry.npmjs.org/eslint-plugin-css-import-order/-/eslint-plugin-css-import-order-1.1.0.tgz"
   integrity sha512-43ODxP1sXpmgI4c+NCtXqmhkLsYGe8El1ewOlvsXKchLjWLxJw5zfp4eEg31Eni+is3jGkBL2TrNyUOOnbOMDg==
 
-eslint-plugin-import@*, "eslint-plugin-import@npm:eslint-plugin-i@^2.29.1":
+"eslint-plugin-import@npm:eslint-plugin-i@^2.29.1":
   version "2.29.1"
   resolved "https://registry.npmjs.org/eslint-plugin-i/-/eslint-plugin-i-2.29.1.tgz"
   integrity sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==
@@ -3554,7 +3673,7 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@*, "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", "eslint@^7.2.0 || ^8", eslint@^8.57.0, "eslint@>= 5.12.1", "eslint@>= 6.0.0 < 9.0.0", eslint@>=7.0.0, eslint@>=8.0.0:
+eslint@^8.57.0:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -3723,7 +3842,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3743,19 +3862,19 @@ fast-uri@^3.0.1:
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-parser@^4.5.0:
-  version "4.5.3"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz"
-  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
-  dependencies:
-    strnum "^1.1.1"
-
 fast-xml-parser@5.3.4:
   version "5.3.4"
   resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz"
   integrity sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==
   dependencies:
     strnum "^2.1.0"
+
+fast-xml-parser@^4.5.0:
+  version "4.5.3"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz"
+  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
+  dependencies:
+    strnum "^1.1.1"
 
 fastq@^1.6.0:
   version "1.20.1"
@@ -3799,13 +3918,6 @@ fill-range@^7.1.1:
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
-
-find-babel-config@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz"
-  integrity sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==
-  dependencies:
-    json5 "^2.2.3"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -3864,7 +3976,7 @@ foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0, form-data@^4.0.4, form-data@4.0.5:
+form-data@4.0.5, form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -3981,16 +4093,6 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^9.3.3:
-  version "9.3.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz"
-  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    minimatch "^8.0.2"
-    minipass "^4.2.4"
-    path-scurry "^1.6.1"
 
 glob@~11.0.0:
   version "11.0.3"
@@ -4120,15 +4222,15 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ieee754@^1.1.4, ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4, ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -4169,7 +4271,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.4, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4571,7 +4673,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@*, jest-resolve@^29.7.0:
+jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -4667,7 +4769,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
+jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -4715,7 +4817,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-"jest@^29.0.0 || ^30.0.0", jest@^29.5.0:
+jest@^29.5.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -4745,6 +4847,13 @@ js-levenshtein@^1.1.6:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.1:
   version "3.14.2"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
@@ -4760,14 +4869,7 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
-jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
+jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -4787,7 +4889,7 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json-pointer@^0.6.2, json-pointer@0.6.2:
+json-pointer@0.6.2, json-pointer@^0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz"
   integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
@@ -5023,6 +5125,13 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^10.0.3:
   version "10.2.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz"
@@ -5044,34 +5153,10 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^8.0.2:
-  version "8.0.7"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz"
-  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-minipass@^4.2.4:
-  version "4.2.8"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz"
-  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
-
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
-  version "7.1.3"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
-  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minipass@^7.1.2:
   version "7.1.3"
@@ -5097,7 +5182,7 @@ mobx-react@^9.1.1:
   dependencies:
     mobx-react-lite "^4.1.1"
 
-mobx@^6.0.4, mobx@^6.9.0:
+mobx@^6.0.4:
   version "6.15.0"
   resolved "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz"
   integrity sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==
@@ -5175,7 +5260,7 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@^2.6.1, node-fetch@^2.6.9, node-fetch@^2.7.0, node-fetch@2.x:
+node-fetch@2.x, node-fetch@^2.6.1, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5353,14 +5438,7 @@ p-finally@^1.0.0:
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
   integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
 
-p-limit@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -5467,14 +5545,6 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.6.1:
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
-  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
-  dependencies:
-    lru-cache "^10.2.0"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-
 path-scurry@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz"
@@ -5551,7 +5621,7 @@ pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8, "pg@>=4.3.0 <9.0.0", pg@>=8.0, pg@8.17.2:
+pg@8.17.2:
   version "8.17.2"
   resolved "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz"
   integrity sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==
@@ -5581,7 +5651,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -5670,7 +5740,7 @@ prettier-linter-helpers@^1.0.1:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.3.2, prettier@>=3.0.0:
+prettier@^3.3.2:
   version "3.8.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz"
   integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
@@ -5737,15 +5807,15 @@ pstree.remy@^1.1.8:
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-punycode@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
-  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
   integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 pure-rand@^6.0.0:
   version "6.1.0"
@@ -5774,7 +5844,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-"react-dom@^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.0 || ^18.2.0 || ^19.2.1", "react-dom@>= 16.8.0":
+"react-dom@^17.0.0 || ^18.2.0 || ^19.2.1":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
@@ -5799,7 +5869,7 @@ react-tabs@^6.0.2:
     clsx "^2.0.0"
     prop-types "^15.5.0"
 
-"react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^17.0.0 || ^18.2.0 || ^19.2.1", "react@^18.0.0 || ^19.0.0", react@^19.2.4, "react@>= 16.8.0":
+"react@^17.0.0 || ^18.2.0 || ^19.2.1":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react/-/react-19.2.4.tgz"
   integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
@@ -5878,11 +5948,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-reselect@^4.1.7:
-  version "4.1.8"
-  resolved "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz"
-  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz"
@@ -5910,7 +5975,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.20.0, resolve@^1.22.4, resolve@^1.22.8:
+resolve@^1.20.0, resolve@^1.22.4:
   version "1.22.11"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz"
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
@@ -5957,27 +6022,22 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-sax@>=0.6.0:
-  version "1.4.4"
-  resolved "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz"
-  integrity sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==
-
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
   integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+sax@>=0.6.0:
+  version "1.4.4"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz"
+  integrity sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==
 
 scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -6197,13 +6257,6 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -6225,6 +6278,13 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -6265,7 +6325,7 @@ strtok3@^10.3.4:
   dependencies:
     "@tokenizer/token" "^0.3.0"
 
-"styled-components@^4.1.1 || ^5.1.1 || ^6.0.5", styled-components@^6.0.7:
+styled-components@^6.0.7:
   version "6.3.9"
   resolved "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz"
   integrity sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==
@@ -6420,7 +6480,7 @@ ts-jest@^29.1.0:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2, ts-node@>=9.0.0:
+ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -6439,7 +6499,7 @@ ts-node@^10.9.2, ts-node@>=9.0.0:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.1.0, tslib@^2.6.2, tslib@2.8.1:
+tslib@2.8.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -6456,15 +6516,15 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
-  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
-
 type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -6491,7 +6551,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.3.3, typescript@>=2.7, typescript@>=4.2.0, "typescript@>=4.3 <6":
+typescript@^5.3.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -6763,19 +6823,6 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.0.1, yargs@^17.3.1, yargs@~17.7.0:
-  version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
 yargs@17.0.1:
   version "17.0.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz"
@@ -6788,6 +6835,19 @@ yargs@17.0.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.0.1, yargs@^17.3.1, yargs@~17.7.0:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Hardens the content/upload endpoints and removes the in-memory buffering of deploy uploads. Came out of a security review of the service; the streaming half pairs with `@dcl/catalyst-storage@4.6.1` (just released) so uploads stream end-to-end.

## Content / endpoint hardening

- **Anonymous upload DoS guard** (`POST /entities`): the multipart parser runs before auth, so it now (a) rejects requests whose `Content-Length` exceeds the per-request limit before reading the body, and (b) caps aggregate in-flight upload bytes via a budget (configurable through `MAX_IN_FLIGHT_UPLOAD_BYTES`), shedding excess with 503.
- **`GET /index` pagination**: the deprecated index endpoint did an uncached N+1 scan of every world and every scene per request. It now uses the standard pagination params (capped page size).
- **`/worlds` search-term cap**: the `search` param fed leading-wildcard ILIKE + trigram similarity across several columns with no length bound. It's now trimmed and length-capped.
- **Thumbnail validation**: world-settings thumbnails are validated by magic bytes (PNG/JPEG/GIF/WebP) instead of being stored unchecked.
- **Thumbnail retrievability**: `GET /contents/:hashId` now accepts both CIDv1 and the SHA-256 hex keys thumbnails are stored under, so generated thumbnail URLs resolve (previously they 400'd).

## Streaming deploy uploads (no in-memory buffering)

- Multipart files are streamed to temp files on disk instead of `Buffer.concat`-ed in memory. A `DeploymentFile` abstraction (`size` / `getStream()` / `asBuffer()`) lets the validator hash content and the deployer store it as a stream; only the small entity JSON and the thumbnail are read fully into memory. Temp files are cleaned up after the handler returns.
- **Bumps `@dcl/catalyst-storage` to `^4.6.1`**, whose S3 `storeStream` now streams via multipart upload (no full-file buffering) and which includes related storage hardening (decompression-bomb cap, path containment, etc.).

Net effect: peak memory on the deploy path drops from "whole deployment in RAM" to a small fixed buffer, end to end.

## Testing

- Build + lint clean.
- **Unit: 655 passed** (incl. new multipart Content-Length/budget/streaming tests, content-file SHA-256 acceptance, validation streaming).
- **Integration: 394 passed** against a local DB. The only failures are the pre-existing `reprocess-ab-handler` tests, which require `AUTH_SECRET=setup_some_secret_here` (unset locally) and fail identically on `main` — unrelated to this change.

> Note: `MAX_IN_FLIGHT_UPLOAD_BYTES` defaults to a container-appropriate value; set it per the deployment's memory/disk. A reverse-proxy body-size/rate limit in front of `POST /entities` is still recommended as defense in depth.