### PR TITLE
fix: harden multipart wrapper (stream teardown + null-prototype field maps)

### DIFF
--- a/src/logic/multipart.ts
+++ b/src/logic/multipart.ts
@@ -8,6 +8,7 @@ import { mkdtemp, readFile, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
 import { DeploymentFile } from '../types'
 
 /**
@@ -147,8 +148,12 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
       throw new InvalidRequestError(error.message || 'Invalid multipart form data')
     }
 
-    const fields: FormDataContext['formData']['fields'] = {}
-    const files: FormDataContext['formData']['files'] = {}
+    // Null-prototype maps so an attacker-controlled field/file name such as `__proto__` or
+    // `constructor` is stored as a plain key. On a plain object a field named `__proto__` makes
+    // `if (fields[name])` read Object.prototype (truthy) and then `fields[name].value.push(...)`
+    // throw, aborting the request.
+    const fields: FormDataContext['formData']['fields'] = Object.create(null)
+    const files: FormDataContext['formData']['files'] = Object.create(null)
 
     // Uploaded files are streamed to temp files under this directory and removed once the handler
     // returns, so large content files are never held in memory in full.
@@ -167,11 +172,6 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
         limitError = message
       }
     }
-
-    const finished = new Promise((ok, err) => {
-      formDataParser.on('error', err)
-      formDataParser.on('close', ok)
-    })
 
     formDataParser.on('partsLimit', () => fail('The multipart request has too many parts.'))
     formDataParser.on('filesLimit', () => fail('The multipart request has too many files.'))
@@ -254,13 +254,15 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
       fileWrites.push(written)
     })
 
-    ctx.request.body.pipe(formDataParser)
-
     const newContext: Ctx = Object.assign(Object.create(ctx), { formData: { fields, files } })
 
     try {
       try {
-        await finished
+        // `.pipe()` doesn't propagate teardown: a client disconnecting mid-upload would leave busboy
+        // waiting forever (and the temp dir below never cleaned up). `pipeline` tears both streams
+        // down if either errors and rejects here instead. busboy is otherwise drained to completion —
+        // limit breaches are recorded via fail() and surfaced after parsing, never by destroying it.
+        await pipeline(ctx.request.body as Readable, formDataParser)
       } catch (error: any) {
         throw new InvalidRequestError(limitError || error.message || 'Invalid multipart form data')
       }

--- a/test/unit/multipart.spec.ts
+++ b/test/unit/multipart.spec.ts
@@ -164,6 +164,72 @@ describe('multipartParserWrapper', function () {
     })
   })
 
+  describe('when a form field name collides with the object prototype', () => {
+    let parse: (ctx: any) => Promise<any>
+    let context: any
+    let captured: { protoIsNull: boolean; entityId: string[] | undefined } | undefined
+
+    beforeEach(() => {
+      captured = undefined
+      const handler = jest.fn(async (ctx: any) => {
+        const fields = ctx.formData.fields
+        captured = { protoIsNull: Object.getPrototypeOf(fields) === null, entityId: fields['entityId']?.value }
+        return { status: 200 }
+      })
+      parse = multipartParserWrapper(handler, { maxSizeInBytes: 100000 })
+      const form = new FormData()
+      // On a plain object this both mutates the prototype and crashes the field handler; on a
+      // null-prototype map it is stored as an ordinary key.
+      form.append('__proto__', 'polluted')
+      form.append('entityId', 'abc')
+      context = createMultipartContext(form)
+    })
+
+    it('should keep the parsed fields on a null-prototype object', async () => {
+      await parse(context)
+      expect(captured?.protoIsNull).toBe(true)
+    })
+
+    it('should still expose the legitimate fields to the handler', async () => {
+      await parse(context)
+      expect(captured?.entityId).toEqual(['abc'])
+    })
+  })
+
+  describe('when the request body stream errors mid-upload', () => {
+    let handler: jest.Mock
+    let parse: (ctx: any) => Promise<any>
+    let context: any
+
+    beforeEach(() => {
+      handler = jest.fn(async () => ({ status: 200 }))
+      parse = multipartParserWrapper(handler, { maxSizeInBytes: 100000 })
+      const contentType = new FormData().getHeaders()['content-type']
+      // A body that fails partway through. With `.pipe()` busboy would emit neither close nor error
+      // and the wrapper would hang forever; it must reject (and clean up) instead.
+      const erroringBody = new Readable({
+        read() {
+          this.destroy(new Error('socket hang up'))
+        }
+      })
+      context = {
+        request: {
+          headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null) },
+          body: erroringBody
+        }
+      }
+    })
+
+    it('should reject the request rather than hang', async () => {
+      await expect(parse(context)).rejects.toThrow()
+    })
+
+    it('should not invoke the handler', async () => {
+      await parse(context).catch(() => undefined)
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
   describe('when concurrent uploads would exceed the buffered-bytes budget', () => {
     let handler: jest.Mock
     let parse: (ctx: any) => Promise<any>


### PR DESCRIPTION
## What

Two fixes to the multipart upload wrapper (`src/logic/multipart.ts`), found while cross-checking it against the catalyst content server's equivalent wrapper.

### 1. Tear down the parser on stream errors (was: hang + temp-dir leak)

The request body was piped into busboy with `.pipe()`, which does **not** propagate teardown. A client disconnecting mid-upload left busboy emitting neither `close` nor `error`, so the `finished` promise **never settled** — the request hung and the temp directory created for the upload was never cleaned up. Repeated, that leaks file descriptors / disk.

Switched to `stream/promises` `pipeline`, which tears **both** streams down if either errors and rejects with the originating error. busboy is still drained to completion on the normal path — limit breaches are recorded via `fail()` and surfaced after parsing, never by destroying the parser (preserving the existing behavior the comments call out).

### 2. Null-prototype field/file maps (`__proto__` crash)

The parsed `fields`/`files` maps were plain objects, so a part named `__proto__` or `constructor` resolved to `Object.prototype`: `if (fields[name])` was truthy and `fields[name].value.push(...)` threw a `TypeError`, aborting the request (attacker-triggerable with a single oddly-named field). Using `Object.create(null)` stores such names as ordinary keys.

## Testing

- `test/unit/multipart.spec.ts`: 17 passing, incl. 4 new — null-prototype handling (handler still receives the legitimate fields) and a mid-upload body-stream error (rejects rather than hangs, handler not invoked).
