### PR TITLE
fix: prevent RPC premature-close from crashing the process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ COPY --from=builderenv /app /app
 #            and: https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/
 ENTRYPOINT ["/sbin/tini", "--"]
 # Run the program under Tini
-CMD [ "/usr/local/bin/node", "--trace-warnings", "--abort-on-uncaught-exception", "--unhandled-rejections=strict", "dist/index.js" ]
+CMD [ "/usr/local/bin/node", "--trace-warnings", "--abort-on-uncaught-exception", "dist/index.js" ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:api": "redocly bundle docs/openapi.yaml -o docs/openapi.json --ext json && redocly build-docs docs/openapi.yaml -o docs/index.html",
     "lint:check": "eslint '**/*.{js,ts}'",
     "lint:fix": "eslint '**/*.{js,ts}' --fix",
-    "start": "node --trace-warnings --abort-on-uncaught-exception --unhandled-rejections=strict dist/index.js",
+    "start": "node --trace-warnings --abort-on-uncaught-exception dist/index.js",
     "dev": "nodemon --watch 'src/**' --ext 'ts,json' --ignore 'src/**/*.spec.ts' --ignore 'src/migrations' --exec 'yarn build && yarn start'",
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose",
     "start:db": "docker-compose up -d && docker exec world_content_server_db bash -c \"until pg_isready; do sleep 1; done\" && sleep 5"

--- a/src/adapters/name-ownership.ts
+++ b/src/adapters/name-ownership.ts
@@ -337,6 +337,29 @@ function chunkArray<T>(array: T[], chunkSize: number): T[][] {
   return chunks
 }
 
+// Transient RPC failures worth retrying: HTTP 400s (Alchemy occasionally returns
+// these for otherwise-valid batches) and network-level errors where the upstream
+// dropped or never completed the connection — most notably node-fetch's
+// ERR_STREAM_PREMATURE_CLOSE ("Premature close") when the RPC closes the socket
+// mid-body, plus resets/timeouts/DNS blips.
+function isRetriableRpcError(error: any): boolean {
+  if (!error) {
+    return false
+  }
+  const retriableCodes = ['ERR_STREAM_PREMATURE_CLOSE', 'ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'ETIMEDOUT', 'EAI_AGAIN']
+  if (error.code && retriableCodes.includes(error.code)) {
+    return true
+  }
+  const message: string = error.message || ''
+  return (
+    message.includes('400') ||
+    message.includes('Premature close') ||
+    message.includes('socket hang up') ||
+    message.includes('network timeout') ||
+    message.includes('ECONNRESET')
+  )
+}
+
 async function sendBatchWithRetry(provider: HTTPProvider, batch: RPCSendableMessage[], maxRetries = 3): Promise<any> {
   // Split large batches into smaller chunks (Alchemy limit is typically 100)
   const BATCH_SIZE_LIMIT = 50 // Conservative limit
@@ -357,15 +380,17 @@ async function sendBatchWithRetry(provider: HTTPProvider, batch: RPCSendableMess
       } catch (error: any) {
         const isLastAttempt = attempt === maxRetries - 1
 
-        // If it's a 400 error and not the last attempt, retry
-        if (error.message && error.message.includes('400') && !isLastAttempt) {
+        // Retry transient failures (HTTP 400s, premature close, resets/timeouts) with backoff
+        if (isRetriableRpcError(error) && !isLastAttempt) {
           const delay = Math.pow(2, attempt) * 1000 // Exponential backoff: 1s, 2s, 4s
-          console.warn(`RPC request failed with 400, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`)
+          console.warn(
+            `RPC request failed (${error.code || error.message}), retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`
+          )
           await new Promise((resolve) => setTimeout(resolve, delay))
           continue
         }
 
-        // For other errors or last attempt, throw the error
+        // For non-retriable errors or last attempt, throw the error
         throw error
       }
     }

--- a/src/adapters/rpc-provider.ts
+++ b/src/adapters/rpc-provider.ts
@@ -1,0 +1,43 @@
+import { IFetchComponent } from '@well-known-components/interfaces'
+import { HTTPProvider } from 'eth-connect'
+
+/**
+ * Builds the eth-connect HTTPProvider used to talk to the configured RPC node.
+ *
+ * eth-connect's HTTPProvider consumes the RPC response body with `await
+ * res.json()` *inside* its `fetch(...).then(onFulfilled)` callback. node-fetch
+ * rejects that body read when the upstream RPC closes the connection mid-body
+ * (`ERR_STREAM_PREMATURE_CLOSE` -> "Invalid response body ...: Premature
+ * close"). Because that rejection happens in the fulfillment handler — not the
+ * `.then(_, onRejected)` handler, and with no trailing `.catch()` — it escapes
+ * as an unhandled promise rejection that crashes the process under
+ * `--unhandled-rejections=strict`. It also bypasses the retry logic in
+ * name-ownership, which only sees errors delivered to the sendAsync callback.
+ *
+ * This wrapper reads (and parses) the body *here*, inside the awaited fetch
+ * call, so a premature close / stream error rejects the fetch promise that
+ * HTTPProvider *does* handle. The failure then reaches the sendAsync callback
+ * as an ordinary, retryable error instead of taking down the server.
+ */
+export function createEthereumProvider({ fetch }: { fetch: IFetchComponent }, rpcUrl: string): HTTPProvider {
+  return new HTTPProvider(rpcUrl, {
+    fetch: async (url: string, init: any) => {
+      const response = await fetch.fetch(url, init)
+
+      // Drain the body inside this awaited call so stream errors (premature
+      // close, connection reset) reject *this* promise rather than escaping
+      // later from inside HTTPProvider's fulfillment handler. Parsing here too
+      // means a malformed body surfaces as a handled rejection rather than a
+      // second unhandled-rejection surface in HTTPProvider's `res.json()`.
+      const body = await response.text()
+      const parsed = body.length > 0 ? JSON.parse(body) : undefined
+
+      return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        json: async () => parsed
+      }
+    }
+  })
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -10,7 +10,6 @@ import { createMetricsComponent } from '@well-known-components/metrics'
 import { createSubgraphComponent } from '@well-known-components/thegraph-component'
 import { AppComponents, GlobalContext, ICommsAdapter, INameDenyListChecker, IWorldNamePermissionChecker } from './types'
 import { metricDeclarations } from './metrics'
-import { HTTPProvider } from 'eth-connect'
 import {
   createFolderBasedFileSystemContentStorage,
   createFsComponent,
@@ -29,6 +28,7 @@ import { createNameDenyListChecker } from './adapters/name-deny-list-checker'
 import { createDatabaseComponent } from './adapters/database-component'
 import { createPermissionsManagerComponent } from './adapters/permissions-manager'
 import { createNameOwnership } from './adapters/name-ownership'
+import { createEthereumProvider } from './adapters/rpc-provider'
 import { createNameChecker } from './adapters/dcl-name-checker'
 import { createWalletStatsComponent } from './adapters/wallet-stats'
 import { createUpdateOwnerJob } from './adapters/update-owner-job'
@@ -97,7 +97,7 @@ export async function initComponents(): Promise<AppComponents> {
   const commsAdapter: ICommsAdapter = await createCommsAdapterComponent({ config, fetch, logs, livekitClient })
 
   const rpcUrl = await config.requireString('RPC_URL')
-  const ethereumProvider = new HTTPProvider(rpcUrl, fetch)
+  const ethereumProvider = createEthereumProvider({ fetch }, rpcUrl)
 
   const storageFolder = (await config.getString('STORAGE_FOLDER')) || 'contents'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,13 @@ import { Lifecycle } from '@well-known-components/interfaces'
 import { initComponents } from './components'
 import { main } from './service'
 
+// Defensive backstop: a stray unhandled promise rejection should be logged and
+// observed, not silently crash the whole server (which would drop every in-flight
+// request and rely on the orchestrator to restart). Known failure modes are fixed
+// at their source in the relevant adapters; this catches anything not yet handled.
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection (process kept alive):', reason)
+})
+
 // This file is the program entry point, it only calls the Lifecycle function
 void Lifecycle.run({ main, initComponents })

--- a/test/unit/rpc-provider.spec.ts
+++ b/test/unit/rpc-provider.spec.ts
@@ -1,0 +1,78 @@
+import { IFetchComponent } from '@well-known-components/interfaces'
+import { HTTPProvider, RPCSendableMessage } from 'eth-connect'
+import { createEthereumProvider } from '../../src/adapters/rpc-provider'
+
+// Promisifies a single HTTPProvider.sendAsync call so the test can assert
+// whether the result/error was delivered to the callback. The whole point of
+// the wrapper is that body-read failures arrive *here* (handled) rather than
+// escaping as an unhandled promise rejection.
+function sendAsyncOnce(provider: HTTPProvider, payload: RPCSendableMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    provider.sendAsync(payload as any, (err: any, result: any) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(result)
+      }
+    })
+  })
+}
+
+describe('when sending a request through the ethereum provider', () => {
+  let fetchMock: jest.Mock
+  let fetch: IFetchComponent
+  let provider: HTTPProvider
+  let payload: RPCSendableMessage
+
+  beforeEach(() => {
+    fetchMock = jest.fn()
+    fetch = { fetch: fetchMock } as unknown as IFetchComponent
+    provider = createEthereumProvider({ fetch }, 'https://rpc.example.org/mainnet')
+    payload = { jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] } as unknown as RPCSendableMessage
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the RPC responds with a valid JSON body', () => {
+    let rpcResult: { jsonrpc: string; id: number; result: string }
+
+    beforeEach(() => {
+      rpcResult = { jsonrpc: '2.0', id: 1, result: '0xabc' }
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify(rpcResult)
+      })
+    })
+
+    it('should deliver the parsed response body to the sendAsync callback', async () => {
+      await expect(sendAsyncOnce(provider, payload)).resolves.toEqual(rpcResult)
+    })
+  })
+
+  describe('and reading the response body fails with a premature close', () => {
+    let prematureCloseError: Error & { code: string; type: string }
+
+    beforeEach(() => {
+      prematureCloseError = Object.assign(
+        new Error('Invalid response body while trying to fetch https://rpc.example.org/mainnet: Premature close'),
+        { type: 'system', code: 'ERR_STREAM_PREMATURE_CLOSE' }
+      )
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => {
+          throw prematureCloseError
+        }
+      })
+    })
+
+    it('should deliver the error to the sendAsync callback rather than letting it escape unhandled', async () => {
+      await expect(sendAsyncOnce(provider, payload)).rejects.toBe(prematureCloseError)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

The server was crashing with:

```
FetchError: Invalid response body while trying to fetch https://rpc.decentraland.org/mainnet?project=worlds-content-server: Premature close
  ... ERR_STREAM_PREMATURE_CLOSE
```

The immediate trigger is transient and upstream: `rpc.decentraland.org` closed the HTTP connection before the (gzipped) response body finished streaming (keep-alive timeout, LB reset, RPC hiccup). That alone should be a retryable failure — instead it took down the whole process.

## Root cause

The RPC calls go through `eth-connect`'s `HTTPProvider`. Its `sendAsync` reads the body with `await res.json()` **inside** the `fetch(...).then(onFulfilled)` fulfillment callback:

```js
fetch(host, init).then(
  async (res) => { if (res.ok) { const body = await res.json() /* rejects here */ ... } },
  (err) => cb(err)   // only catches the fetch() promise itself
) // no trailing .catch()
```

When the body read rejects, the rejection is **not** routed to the second `.then` argument and there's no trailing `.catch()`, so it escapes as an **unhandled promise rejection**. Combined with `--unhandled-rejections=strict` (in `package.json` + `Dockerfile`), that terminates the process. It also bypassed the existing retry logic in `name-ownership.ts`, which only sees errors delivered to the `sendAsync` callback.

## Changes

- **`src/adapters/rpc-provider.ts` (new)** — `createEthereumProvider` wraps the fetch component so the RPC body is read and parsed *inside the awaited fetch call*. A premature close / stream error now rejects the fetch promise that `HTTPProvider` **does** handle, so it reaches the `sendAsync` callback as an ordinary, retryable error instead of crashing.
- **`src/adapters/name-ownership.ts`** — broaden `sendBatchWithRetry` to retry transient network failures (`ERR_STREAM_PREMATURE_CLOSE`, `ECONNRESET`, timeouts, DNS blips), not just HTTP 400s.
- **`src/index.ts` + flags** — add a process-level `unhandledRejection` backstop that logs and keeps the server alive, and drop `--unhandled-rejections=strict` from `package.json` and `Dockerfile`. The handler is a **no-op while `strict` is set** (verified empirically: process still exits 1), so the flag change is what makes the backstop effective. `--abort-on-uncaught-exception` is kept for genuine uncaught exceptions.

## Tests

- New `test/unit/rpc-provider.spec.ts`: verifies a valid body is parsed and delivered to the callback, and that a premature-close body-read error is **delivered to the `sendAsync` callback** (the handled path) rather than escaping unhandled.
- Existing `test/unit/name-ownership.spec.ts` still passes (18 tests).

`tsc --noEmit`, eslint, and the targeted suites are green.