### PR TITLE
fix: serve detected mime type as content-type instead of octet-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "busboy": "^1.6.0",
     "cron": "^3.1.6",
     "eth-connect": "^6.2.4",
+    "file-type": "^16",
     "livekit-server-sdk": "^2.10.1",
     "lru-cache": "^10.2.0",
     "p-queue": "^6.6.2"

--- a/src/controllers/handlers/content-file-handler.ts
+++ b/src/controllers/handlers/content-file-handler.ts
@@ -3,9 +3,42 @@ import { IPFSv2 } from '@dcl/schemas'
 import { HandlerContextWithPath } from '../../types'
 import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
 import { InvalidRequestError } from '@dcl/http-commons'
+import { fromStream } from 'file-type'
+import { Readable } from 'stream'
 
 const EXPOSED_HEADERS = 'ETag, Accept-Ranges, Content-Range'
 export const MAX_AVAILABLE_CONTENT_CIDS = 500
+
+const DEFAULT_CONTENT_TYPE = 'application/octet-stream'
+
+// file-type inspects magic bytes near the start of the file; 4100 bytes is its internal sample
+// size and is enough to recognize every format it supports.
+const MIME_SNIFF_BYTES = 4100
+
+// Content is addressed by hash, so the request carries no file name or extension to derive a MIME
+// type from. We detect it by sniffing the file's magic bytes. The detected type describes the full
+// representation, so it is also correct for partial (206) responses. Anything file-type cannot
+// recognize (plain text, JSON, glTF, ...) falls back to application/octet-stream.
+//
+// We sniff the raw stream: worlds content is always stored uncompressed (deploys use storeStream,
+// never storeStreamAndCompress), so the raw bytes are the real bytes. We skip detection for any
+// compressed item rather than route it through asStream(), which would pipe the source into a
+// gunzip transform whose source stream destroy() does not tear down (an fd/socket leak).
+async function detectContentType(item: ContentItem): Promise<string> {
+  if (item.encoding) return DEFAULT_CONTENT_TYPE
+
+  let stream: Readable | undefined
+  try {
+    stream = await item.asRawStream()
+    const result = await fromStream(stream)
+    return result?.mime ?? DEFAULT_CONTENT_TYPE
+  } catch {
+    return DEFAULT_CONTENT_TYPE
+  } finally {
+    // We only need the head of the file; destroying the stream aborts any remaining transfer.
+    stream?.destroy()
+  }
+}
 
 // Content is addressed by IPFS CIDv1, but world thumbnails have historically been stored under a
 // raw SHA-256 hex digest. Accept both when serving so those legacy thumbnails remain retrievable.
@@ -17,9 +50,9 @@ function isRetrievableContentKey(hashId: string): boolean {
   return IPFSv2.validate(hashId) || SHA256_HEX.test(hashId)
 }
 
-function contentItemHeaders(content: ContentItem, hashId: string) {
+function contentItemHeaders(content: ContentItem, hashId: string, contentType: string) {
   const ret: Record<string, string> = {
-    'Content-Type': 'application/octet-stream',
+    'Content-Type': contentType,
     ETag: JSON.stringify(hashId), // by spec, the ETag must be a double-quoted string
     'Access-Control-Expose-Headers': EXPOSED_HEADERS,
     'Cache-Control': 'public,max-age=31536000,s-maxage=31536000,immutable'
@@ -83,7 +116,8 @@ async function retrieveFullContent(
 ): Promise<IHttpServerComponent.IResponse> {
   const file = await storage.retrieve(hashId)
   if (!file) return { status: 404 }
-  return { status: 200, headers: contentItemHeaders(file, hashId), body: await file.asRawStream() }
+  const contentType = await detectContentType(file)
+  return { status: 200, headers: contentItemHeaders(file, hashId, contentType), body: await file.asRawStream() }
 }
 
 export async function getContentFile(
@@ -139,10 +173,19 @@ export async function getContentFile(
   }
   if (!file) return { status: 404 }
 
+  // Sniff the MIME type from the start of the file, not the requested range (which may begin
+  // mid-file). encoding is null here (compressed content bailed out above), so a small read from
+  // offset 0 yields valid bytes to inspect.
+  const head = await ctx.components.storage.retrieve(ctx.params.hashId, {
+    start: 0,
+    end: Math.min(MIME_SNIFF_BYTES - 1, fileInfo.size - 1)
+  })
+  const contentType = head ? await detectContentType(head) : DEFAULT_CONTENT_TYPE
+
   return {
     status: 206,
     headers: {
-      ...contentItemHeaders(file, ctx.params.hashId),
+      ...contentItemHeaders(file, ctx.params.hashId, contentType),
       'Content-Length': (range.end - range.start + 1).toString(),
       'Content-Range': `bytes ${range.start}-${range.end}/${fileInfo.size}`
     },
@@ -159,7 +202,8 @@ export async function headContentFile(
 
   if (!file) return { status: 404 }
 
-  return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId) }
+  const contentType = await detectContentType(file)
+  return { status: 200, headers: contentItemHeaders(file, ctx.params.hashId, contentType) }
 }
 
 export async function availableContentHandler(

--- a/test/unit/content-file-handler.spec.ts
+++ b/test/unit/content-file-handler.spec.ts
@@ -189,13 +189,20 @@ describe('getContentFile', () => {
   const hashId = 'bafkreiahsvnr4x4rnskhkwfbnbplkbqhzb3xagdwpyfy44lgcndmhyizde'
   const fileContent = Buffer.from('test content')
 
-  function createContentItem(overrides: Partial<ContentItem> = {}): ContentItem {
+  // Minimal but valid magic bytes so file-type recognizes the content.
+  const mp4Content = Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32, 0x00, 0x00, 0x00, 0x00, 0x6d, 0x70, 0x34,
+    0x32, 0x69, 0x73, 0x6f, 0x6d
+  ])
+
+  function createContentItem(content: Buffer = fileContent, overrides: Partial<ContentItem> = {}): ContentItem {
     return {
       encoding: null,
-      size: fileContent.length,
-      contentSize: fileContent.length,
-      asStream: jest.fn().mockResolvedValue(Readable.from(fileContent)),
-      asRawStream: jest.fn().mockResolvedValue(Readable.from(fileContent)),
+      size: content.length,
+      contentSize: content.length,
+      // Fresh streams per call so detection and body reads don't share a consumed stream.
+      asStream: jest.fn().mockImplementation(async () => Readable.from(content)),
+      asRawStream: jest.fn().mockImplementation(async () => Readable.from(content)),
       ...overrides
     }
   }
@@ -222,9 +229,10 @@ describe('getContentFile', () => {
   describe('when the file has compressed encoding and a Range header is sent', () => {
     let response: IHttpServerComponent.IResponse
     let storageMock: Partial<IContentStorageComponent>
+    let compressedItem: ContentItem
 
     beforeEach(async () => {
-      const compressedItem = createContentItem({ encoding: 'gzip' })
+      compressedItem = createContentItem(fileContent, { encoding: 'gzip' })
       storageMock = {
         fileInfo: jest.fn().mockResolvedValue({ encoding: 'gzip', size: 100, contentSize: 200 }),
         retrieve: jest.fn().mockResolvedValue(compressedItem)
@@ -243,6 +251,16 @@ describe('getContentFile', () => {
     it('should not advertise Accept-Ranges', () => {
       expect(response.headers!['Accept-Ranges']).toBeUndefined()
     })
+
+    it('should skip MIME detection and fall back to application/octet-stream', () => {
+      expect((response.headers as Record<string, string>)['Content-Type']).toEqual('application/octet-stream')
+    })
+
+    it('should not read the raw stream to sniff a compressed item', () => {
+      // asRawStream is called once for the body, never a second time for detection (which would
+      // require routing a compressed stream through a gunzip pipe we cannot reliably tear down).
+      expect(compressedItem.asRawStream).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('when the file size is null and a Range header is sent', () => {
@@ -250,7 +268,7 @@ describe('getContentFile', () => {
     let storageMock: Partial<IContentStorageComponent>
 
     beforeEach(async () => {
-      const item = createContentItem({ size: null })
+      const item = createContentItem(fileContent, { size: null })
       storageMock = {
         fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: null, contentSize: null }),
         retrieve: jest.fn().mockResolvedValue(item)
@@ -272,7 +290,7 @@ describe('getContentFile', () => {
     let storageMock: Partial<IContentStorageComponent>
 
     beforeEach(async () => {
-      const rangedItem = createContentItem({ size: 5 })
+      const rangedItem = createContentItem(fileContent, { size: 5 })
       storageMock = {
         fileInfo: jest
           .fn()
@@ -406,6 +424,70 @@ describe('getContentFile', () => {
 
     it('should not call fileInfo', () => {
       expect(storageMock.fileInfo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when serving full content of a recognizable file type', () => {
+    let response: IHttpServerComponent.IResponse
+
+    beforeEach(async () => {
+      const item = createContentItem(mp4Content)
+      const storageMock: Partial<IContentStorageComponent> = {
+        fileInfo: jest.fn(),
+        retrieve: jest.fn().mockResolvedValue(item)
+      }
+      response = await getContentFile(createContext(storageMock))
+    })
+
+    it('should set the Content-Type to the detected MIME type', () => {
+      expect((response.headers as Record<string, string>)['Content-Type']).toEqual('video/mp4')
+    })
+  })
+
+  describe('when serving full content of an unrecognizable file type', () => {
+    let response: IHttpServerComponent.IResponse
+
+    beforeEach(async () => {
+      const item = createContentItem() // plain text: no recognizable magic bytes
+      const storageMock: Partial<IContentStorageComponent> = {
+        fileInfo: jest.fn(),
+        retrieve: jest.fn().mockResolvedValue(item)
+      }
+      response = await getContentFile(createContext(storageMock))
+    })
+
+    it('should fall back to application/octet-stream', () => {
+      expect((response.headers as Record<string, string>)['Content-Type']).toEqual('application/octet-stream')
+    })
+  })
+
+  describe('when serving a byte range of a recognizable file type', () => {
+    let response: IHttpServerComponent.IResponse
+    let storageMock: Partial<IContentStorageComponent>
+
+    beforeEach(async () => {
+      // The requested range starts mid-file; the type must still be detected from the file start.
+      storageMock = {
+        fileInfo: jest.fn().mockResolvedValue({ encoding: null, size: 5000, contentSize: 5000 }),
+        retrieve: jest
+          .fn()
+          .mockImplementation(async (_id: string, range?: { start: number; end: number }) =>
+            createContentItem(mp4Content, { size: range ? range.end - range.start + 1 : mp4Content.length })
+          )
+      }
+      response = await getContentFile(createContext(storageMock, 'bytes=1000-2000'))
+    })
+
+    it('should respond with 206', () => {
+      expect(response.status).toEqual(206)
+    })
+
+    it('should sniff the MIME type from the start of the file', () => {
+      expect(storageMock.retrieve).toHaveBeenCalledWith(hashId, { start: 0, end: 4099 })
+    })
+
+    it('should set the Content-Type to the detected MIME type', () => {
+      expect((response.headers as Record<string, string>)['Content-Type']).toEqual('video/mp4')
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,7 +2959,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3070,6 +3070,14 @@ buffer@4.9.2:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bundle-name@^4.1.0:
   version "4.1.0"
@@ -3818,6 +3826,11 @@ events@1.1.1:
   resolved "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
@@ -3929,6 +3942,15 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-type@^16:
+  version "16.5.4"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
+  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.2.4"
+    token-types "^4.1.1"
 
 file-type@^21.1.1:
   version "21.3.4"
@@ -5597,6 +5619,11 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+peek-readable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
+  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
+
 perfect-scrollbar@^1.5.5:
   version "1.5.6"
   resolved "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz"
@@ -5788,6 +5815,11 @@ prismjs@^1.29.0:
   resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 prom-client@^15.1.0:
   version "15.1.3"
   resolved "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz"
@@ -5911,6 +5943,24 @@ readable-stream@^3.0.2, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.7.0.tgz#cedbd8a1146c13dfff8dab14068028d58c15ac91"
+  integrity sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz#392ba37707af5bf62d725c36c1b5d6ef4119eefc"
+  integrity sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==
+  dependencies:
+    readable-stream "^4.7.0"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -6301,7 +6351,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string_decoder@^1.1.1:
+string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -6346,6 +6396,14 @@ strtok3@^10.3.4:
   integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
+
+strtok3@^6.2.4:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
+  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^4.1.0"
 
 styled-components@^6.0.7:
   version "6.3.9"
@@ -6462,6 +6520,14 @@ toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+token-types@^4.1.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.1.tgz#0f897f03665846982806e138977dbe72d44df753"
+  integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
 
 token-types@^6.1.1:
   version "6.1.2"


### PR DESCRIPTION
## Changes

- `GET`/`HEAD /contents/:hashId` and `/ipfs/:hashId` now derive the `Content-Type` from the file's magic bytes (via `file-type`) instead of always returning `application/octet-stream`. This fixes videos (and other media) being served as `octet-stream`.
- For range (`206`) responses the type is sniffed from a small read at the **start** of the file, so the `Content-Type` is correct regardless of the requested byte range (players seek mid-file).
- Compressed items skip detection — worlds content is always stored uncompressed (`storeStream`, never `storeStreamAndCompress`) — which also avoids an unreliable gunzip-stream teardown / fd leak. Unrecognized formats (text, JSON, glTF, …) fall back to `application/octet-stream`.
- Pinned `file-type@^16` (CommonJS); v17+ is ESM-only and would break the `tsc` CommonJS build.

## Context

The reported symptom: `worlds-content-server` returns `application/octet-stream` for videos. Root cause: the handler hardcoded that content type and never derived the real one. The serving-side MIME detection (originally on the `mimetype` branch, commit `3e6e13d`) was never merged to `main`; the Dec 2025 webm fix (#412) only touched the deploy/storage side, not the serving header.

## Test plan

- [x] Unit tests cover full (`200`), range (`206`, sniffed from offset 0), `HEAD`, and the compressed-item fallback
- [x] `yarn lint:fix`, `yarn build`, and `yarn jest test/unit` all green (678 unit tests)
- [ ] Integration tests require Postgres (Docker) — not run locally; verified they assert status/range/length only, not `Content-Type`, and use plain-text fixtures (unaffected)