### PR TITLE
fix: tolerate null entries in the name deny list payload

### DIFF
--- a/src/adapters/name-deny-list-checker.ts
+++ b/src/adapters/name-deny-list-checker.ts
@@ -24,7 +24,9 @@ export async function createNameDenyListChecker(
           const response = await components.fetch.fetch(`${url}/banned-names`, { method: 'POST' })
           const list = (await response.json())['data']
           logger.debug(`Fetched list: ${list}`)
-          return list
+          // Guard against a malformed payload (missing/non-array data or null/non-string entries),
+          // otherwise a null entry crashes consumers that call .toLowerCase()/.replace() on it.
+          return Array.isArray(list) ? list.filter((name): name is string => typeof name === 'string') : []
         } catch (error) {
           logger.warn(`Failed to fetch name deny list from ${url}/banned-names: ${error}`)
           return []

--- a/test/unit/name-deny-list-checker.spec.ts
+++ b/test/unit/name-deny-list-checker.spec.ts
@@ -70,6 +70,42 @@ describe('name deny list checker', function () {
     await expect(nameDenyListChecker.checkNameDenyList('good-name.eth')).resolves.toBeTruthy()
   })
 
+  it('when the fetched list contains null or non-string entries, it ignores them instead of crashing', async () => {
+    const fetch = await createFetchComponent()
+    fetch.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: ['banned-name', null, undefined, 42, 'another-banned']
+        })
+    })
+    const nameDenyListChecker = await createNameDenyListChecker({
+      config,
+      logs,
+      fetch
+    })
+
+    await expect(nameDenyListChecker.checkNameDenyList('good-name.dcl.eth')).resolves.toBeTruthy()
+    await expect(nameDenyListChecker.checkNameDenyList('banned-name.dcl.eth')).resolves.toBeFalsy()
+    await expect(nameDenyListChecker.getBannedNames()).resolves.toEqual(['banned-name', 'another-banned'])
+  })
+
+  it('when the fetched payload has no array data, it degrades to an empty list', async () => {
+    const fetch = await createFetchComponent()
+    fetch.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: null })
+    })
+    const nameDenyListChecker = await createNameDenyListChecker({
+      config,
+      logs,
+      fetch
+    })
+
+    await expect(nameDenyListChecker.checkNameDenyList('any-name.dcl.eth')).resolves.toBeTruthy()
+    await expect(nameDenyListChecker.getBannedNames()).resolves.toEqual([])
+  })
+
   it('when fetch fails, it gracefully degrades and allows all names', async () => {
     const fetch = await createFetchComponent()
     fetch.fetch = jest.fn().mockRejectedValue(new Error('Premature close'))


### PR DESCRIPTION
## Problem

Users hit repeated 500s across multiple world endpoints:

```
Error handling .../world/pravus.dcl.eth/about: Cannot read properties of null (reading 'toLowerCase')
Error handling .../world/impssbldimnsn.dcl.eth/permissions: Cannot read properties of null (reading 'replace')
Error handling .../entities: Cannot read properties of null (reading 'toLowerCase')
Error handling .../get-comms-adapter/world-prd-mannakia.dcl.eth: Cannot read properties of null (reading 'replace')
```

## Root cause

The `dcl-lists` `POST /banned-names` endpoint is returning a `data` array that contains literal `null` entries, e.g.:

```json
{"data":["<name>", null, "<name>", "<name>", null, ...]}
```

`createNameDenyListChecker` cached that array verbatim, so any consumer iterating it dereferenced a `null` element:

- `checkNameDenyList` → `name.toLowerCase()` in `.some(...)` → **`reading 'toLowerCase'`** — hit by `/world/:name/about` and `/entities`.
- `getBannedNames` → `name.replace(...)` in `.map(...)` → **`reading 'replace'`** — hit by `/world/:name/permissions` and `/get-comms-adapter` (via `access.getAccessForWorld` / `worlds.isWorldValid` → `getRawWorldRecords`).

The existing optional chaining only guarded the array being `null`, not `null` elements inside it. #495 handled a *failed* fetch, but a *successful* fetch returning dirty data still poisoned the hour-long cache.

## Fix

Sanitize the fetched list at the source so the cache's `string[]` invariant actually holds and every consumer is protected. Also degrade to an empty list when `data` is missing or not an array.

```ts
return Array.isArray(list) ? list.filter((name): name is string => typeof name === 'string') : []
```

## Tests

Added two regression cases to `name-deny-list-checker.spec.ts`:
- null/non-string entries are ignored instead of crashing (and `getBannedNames` returns only the valid names).
- a non-array `data` payload degrades to an empty list.

All 7 tests pass; `tsc --noEmit` is clean.

## Follow-up (out of scope)

This is a client-side guard. The `dcl-lists` `/banned-names` endpoint should not emit `null` entries in `data` in the first place — worth a separate issue with that service's owners, since other consumers likely hit the same crash.