### PR TITLE
feat: support partial (multi-request) scene uploads

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -81,3 +81,5 @@ SHARED_SECRET_MAX_ATTEMPTS_PER_MINUTE=3
 ######################################
 # How long to keep UNDEPLOYED scenes before permanent deletion (ms). Default: 7 days
 SCENE_EVICTION_TTL_MS=604800000
+# How long a partial (multi-request) deployment may stay pending before it is reclaimed (ms). Default 24h.
+PENDING_DEPLOYMENT_TTL=86400000

--- a/.env.default
+++ b/.env.default
@@ -83,3 +83,5 @@ SHARED_SECRET_MAX_ATTEMPTS_PER_MINUTE=3
 SCENE_EVICTION_TTL_MS=604800000
 # How long a partial (multi-request) deployment may stay pending before it is reclaimed (ms). Default 24h.
 PENDING_DEPLOYMENT_TTL=86400000
+# Max concurrent non-expired pending (partial) uploads a single deployer may have in flight. Default 10.
+MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER=10

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -11,7 +11,20 @@ The database contains the following main tables:
 3. **`world_permissions`** - Stores deployment and streaming permission grants
 4. **`world_permission_parcels`** - Stores parcel-level permission restrictions (normalized)
 5. **`blocked`** - Stores blocked wallet addresses
-6. **`migrations`** - Tracks executed database migrations (internal, managed automatically)
+6. **`pending_scenes`** - Stores partial (multi-request) deployments still being uploaded (not yet live)
+7. **`migrations`** - Tracks executed database migrations (internal, managed automatically)
+
+### Table: `pending_scenes`
+
+Staging area for partial deployments: a scene's content can be uploaded across several `POST /entities`
+requests (with `partial=true`), and the entity only becomes a live `world_scenes` row once every
+referenced file is present. Intentionally has **no** foreign key to `worlds` — a half-uploaded world must
+not create a `worlds` row (which would leak into listings and world-validity checks) before it goes live.
+The authoritative entity bytes live in content storage under the entity id; the `entity` JSONB here is a
+copy used by garbage collection. Columns: `entity_id` (PK), `world_name`, `parcels` (TEXT[]), `entity`
+(JSONB), `deployer`, `created_at`/`updated_at` (TIMESTAMPTZ). At most one non-expired pending scene may
+exist per world + overlapping parcels; rows expire after `PENDING_DEPLOYMENT_TTL` (default 24h) and are
+removed by the daily eviction job. `created_at` anchors the deployment-TTL check for staged uploads.
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -306,8 +306,19 @@ paths:
         - Content Server
       summary: /entities
       description: |
-        Deploy a new scene to a world. The deployment must include entity metadata and all content files.
-        Requires authentication via auth chain.
+        Deploy a new scene to a world. Requires authentication via auth chain.
+
+        A standard deployment includes the entity metadata file and every content file it references
+        in a single request, and returns `200`.
+
+        **Partial (multi-request) deployments.** For scenes too large for one request, send `partial`
+        set to `"true"` and split the content files across several requests. The first partial request
+        must include the entity metadata file; later requests may omit it (it is read back from
+        storage). Each request stores the files it carries; the scene only goes live once every
+        referenced file is present. A request that still leaves files missing returns `202` with the
+        list of outstanding hashes; the request that completes the set runs full validation, deploys,
+        and returns `200`. At most one in-flight partial deployment is kept per set of parcels (a newer
+        one replaces it), and staged content expires if the upload is not completed in time.
       operationId: worldsContentServer_deployEntity
       requestBody:
         required: true
@@ -322,13 +333,19 @@ paths:
                   type: string
                   description: The entity ID (IPFS hash)
                   example: bafkreiabi74jam7uh5gmm6x4hox664j53bmt7dy4alrltkhyj3ozcxs2iu
+                partial:
+                  type: string
+                  enum: ['true']
+                  description: >
+                    Set to "true" to mark this request as a staging request of a partial
+                    (multi-request) deployment. Omit for a standard single-request deployment.
               additionalProperties:
                 type: string
                 format: binary
                 description: Content files referenced by the entity
       responses:
         '200':
-          description: Entity deployed successfully
+          description: Entity deployed successfully (all content present)
           content:
             application/json:
               schema:
@@ -340,6 +357,20 @@ paths:
                   message:
                     type: string
                     description: Deployment confirmation message
+        '202':
+          description: >
+            Partial deployment accepted but not yet complete: some referenced content files are still
+            missing. Send them in further requests to complete the deployment.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  missing:
+                    type: array
+                    items:
+                      type: string
+                    description: Content hashes still missing before the scene can go live
         '400':
           description: Invalid request or deployment failed validation
           content:

--- a/src/adapters/entity-deployer.ts
+++ b/src/adapters/entity-deployer.ts
@@ -2,6 +2,7 @@ import { AppComponents, DeploymentFile, DeploymentResult, IEntityDeployer } from
 import { AuthLink, Entity, EntityType, Events, WorldDeploymentEvent } from '@dcl/schemas'
 import { bufferToStream } from '@dcl/catalyst-storage/dist/content-item'
 import { stringToUtf8Bytes } from 'eth-connect'
+import { InvalidRequestError } from '@dcl/http-commons'
 
 type PostDeploymentHook = (baseUrl: string, entity: Entity, authChain: AuthLink[]) => Promise<DeploymentResult>
 
@@ -22,6 +23,18 @@ export function createEntityDeployer(
     entityJson: string,
     authChain: AuthLink[]
   ): Promise<DeploymentResult> {
+    // Fast-fail BEFORE writing anything to storage if a newer scene already holds these parcels. This is
+    // non-authoritative (deployScene re-checks atomically under a lock), but it keeps a rejected older
+    // deploy from leaving its content/entity/auth objects orphaned in storage until the next GC. Only
+    // scenes carry a world name; other entity types skip it.
+    if (entity.metadata?.worldConfiguration?.name) {
+      if (await worldsManager.hasNewerDeployedScene(entity.metadata.worldConfiguration.name, entity)) {
+        throw new InvalidRequestError(
+          `Deployment failed: a newer scene is already deployed on one or more of these parcels.`
+        )
+      }
+    }
+
     // store all files
     const content = entity.content || []
     logger.info(`Storing ${content.length} files`, { entityId: entity.id })

--- a/src/adapters/eviction-job.ts
+++ b/src/adapters/eviction-job.ts
@@ -2,7 +2,6 @@ import { createJobComponent, IJobComponent } from '@dcl/job-component'
 import { AppComponents } from '../types'
 
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
-const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
 export async function createEvictionJob(
@@ -11,14 +10,14 @@ export async function createEvictionJob(
   const { config, logs, worlds, pendingScenesManager } = components
   const logger = logs.getLogger('eviction-job')
   const evictionTtlMs = (await config.getNumber('SCENE_EVICTION_TTL_MS')) ?? DEFAULT_TTL_MS
-  const pendingTtlMs = (await config.getNumber('PENDING_DEPLOYMENT_TTL')) ?? DEFAULT_PENDING_DEPLOYMENT_TTL_MS
 
   return createJobComponent(
     { logs },
     async () => {
       logger.info('Running eviction job...')
       const evicted = await worlds.evictUndeployedWorlds(evictionTtlMs)
-      const expiredPending = await pendingScenesManager.deleteExpired(pendingTtlMs)
+      // The pending-scenes manager owns the PENDING_DEPLOYMENT_TTL, so expiry uses its configured value.
+      const expiredPending = await pendingScenesManager.deleteExpired()
       logger.info(`Eviction completed. Deleted ${evicted} scene(s) and ${expiredPending} expired pending upload(s).`)
     },
     ONE_DAY_MS,

--- a/src/adapters/eviction-job.ts
+++ b/src/adapters/eviction-job.ts
@@ -2,21 +2,24 @@ import { createJobComponent, IJobComponent } from '@dcl/job-component'
 import { AppComponents } from '../types'
 
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
 export async function createEvictionJob(
-  components: Pick<AppComponents, 'config' | 'logs' | 'worlds'>
+  components: Pick<AppComponents, 'config' | 'logs' | 'worlds' | 'pendingScenesManager'>
 ): Promise<IJobComponent> {
-  const { config, logs, worlds } = components
+  const { config, logs, worlds, pendingScenesManager } = components
   const logger = logs.getLogger('eviction-job')
   const evictionTtlMs = (await config.getNumber('SCENE_EVICTION_TTL_MS')) ?? DEFAULT_TTL_MS
+  const pendingTtlMs = (await config.getNumber('PENDING_DEPLOYMENT_TTL')) ?? DEFAULT_PENDING_DEPLOYMENT_TTL_MS
 
   return createJobComponent(
     { logs },
     async () => {
       logger.info('Running eviction job...')
       const evicted = await worlds.evictUndeployedWorlds(evictionTtlMs)
-      logger.info(`Eviction completed. Deleted ${evicted} scene(s).`)
+      const expiredPending = await pendingScenesManager.deleteExpired(pendingTtlMs)
+      logger.info(`Eviction completed. Deleted ${evicted} scene(s) and ${expiredPending} expired pending upload(s).`)
     },
     ONE_DAY_MS,
     { repeat: true, onError: (err) => logger.error(`Eviction job failed: ${err}`) }

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -75,8 +75,8 @@ export async function createPendingScenesManager(
     await database.query(SQL`DELETE FROM pending_scenes WHERE entity_id = ${entityId}`)
   }
 
-  async function deleteExpired(olderThanMs: number): Promise<number> {
-    const cutoff = new Date(Date.now() - olderThanMs)
+  async function deleteExpired(): Promise<number> {
+    const cutoff = new Date(Date.now() - ttlMs)
     const result = await database.query(SQL`DELETE FROM pending_scenes WHERE created_at < ${cutoff}`)
     const removed = result.rowCount ?? 0
     if (removed > 0) {
@@ -85,5 +85,23 @@ export async function createPendingScenesManager(
     return removed
   }
 
-  return { getByEntityId, upsert, deleteByEntityId, deleteExpired }
+  async function getActivePendingKeys(): Promise<Set<string>> {
+    const cutoff = new Date(Date.now() - ttlMs)
+    const result = await database.query<{ entity_id: string; entity: Entity }>(
+      SQL`SELECT entity_id, entity FROM pending_scenes WHERE created_at >= ${cutoff}`
+    )
+    const keys = new Set<string>()
+    for (const row of result.rows) {
+      // The staged entity JSON, its auth-chain blob, and every content file it references are all
+      // referenced by the in-flight upload even though no world_scenes row exists yet.
+      keys.add(row.entity_id)
+      keys.add(`${row.entity_id}.auth`)
+      for (const file of row.entity.content ?? []) {
+        keys.add(file.hash)
+      }
+    }
+    return keys
+  }
+
+  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys }
 }

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -1,5 +1,6 @@
 import SQL from 'sql-template-strings'
 import { Entity } from '@dcl/schemas'
+import { InvalidRequestError } from '@dcl/http-commons'
 import { AppComponents, IPendingScenesManager, PendingScene, UpsertPendingScene } from '../types'
 
 const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
@@ -53,8 +54,28 @@ export async function createPendingScenesManager(
       // processes) so two concurrent uploads for the same world+parcels can't both insert.
       await database.query(SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_scenes:' + worldName}, 0))`)
 
+      // The single pending slot per parcel set goes to the NEWEST scene (Decentraland deployment
+      // ordering: greater entity.timestamp, tie broken by greater entity id). Reject rather than
+      // replace when a strictly-newer overlapping upload is already in flight, so a stale/older upload
+      // can't evict a newer competitor's staged content (and two clients can't ping-pong evicting each
+      // other). A resume (same entity id) is excluded and never conflicts with itself.
+      const newer = await database.query(SQL`
+        SELECT 1 FROM pending_scenes
+        WHERE world_name = ${worldName}
+          AND parcels && ${input.parcels}::text[]
+          AND entity_id != ${input.entityId}
+          AND created_at >= ${expiryCutoff}
+          AND ( (entity->>'timestamp')::bigint > ${input.entity.timestamp}
+                OR ((entity->>'timestamp')::bigint = ${input.entity.timestamp} AND entity_id > ${input.entityId}) )
+        LIMIT 1
+      `)
+      if (newer.rowCount > 0) {
+        throw new InvalidRequestError('A newer partial upload is already in progress for one or more of these parcels.')
+      }
+
       // Purge expired rows and replace any non-expired pending scene of this world whose parcels
-      // overlap the new one (a different entity id) — enforcing one pending upload per world+parcel.
+      // overlap the new one (a different entity id). Having rejected the newer-conflict above, every
+      // remaining overlapping row is strictly older, so replacing it is the intended "newest wins".
       await database.query(SQL`
         DELETE FROM pending_scenes
         WHERE created_at < ${expiryCutoff}
@@ -73,6 +94,15 @@ export async function createPendingScenesManager(
 
   async function deleteByEntityId(entityId: string): Promise<void> {
     await database.query(SQL`DELETE FROM pending_scenes WHERE entity_id = ${entityId}`)
+  }
+
+  async function countActiveByDeployer(deployer: string): Promise<number> {
+    const cutoff = new Date(Date.now() - ttlMs)
+    const result = await database.query<{ count: string }>(
+      SQL`SELECT COUNT(*) as count FROM pending_scenes
+          WHERE deployer = ${deployer.toLowerCase()} AND created_at >= ${cutoff}`
+    )
+    return parseInt(result.rows[0].count, 10)
   }
 
   async function deleteExpired(): Promise<number> {
@@ -114,5 +144,5 @@ export async function createPendingScenesManager(
     return keys
   }
 
-  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys }
+  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys, countActiveByDeployer }
 }

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -89,10 +89,15 @@ export async function createPendingScenesManager(
     const cutoff = new Date(Date.now() - ttlMs)
     // Project only the content hashes out of the entity JSONB instead of shipping every pending
     // scene's full manifest: GC calls this once per delete batch, so on a large sweep the payload
-    // size matters more than the (tiny) row count.
+    // size matters more than the (tiny) row count. The jsonb_typeof guard keeps a row whose `content`
+    // is absent, null, or a non-array from erroring `jsonb_array_elements` ('cannot extract elements
+    // from a scalar') — one such row would otherwise fail the whole query and wedge GC server-wide.
     const result = await database.query<{ entity_id: string; hashes: string[] | null }>(
       SQL`SELECT entity_id,
-                 ARRAY(SELECT jsonb_array_elements(entity->'content')->>'hash') AS hashes
+                 ARRAY(
+                   SELECT jsonb_array_elements(entity->'content')->>'hash'
+                   WHERE jsonb_typeof(entity->'content') = 'array'
+                 ) AS hashes
           FROM pending_scenes
           WHERE created_at >= ${cutoff}`
     )

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -45,11 +45,29 @@ export async function createPendingScenesManager(
     return result.rows.length > 0 ? toPendingScene(result.rows[0]) : undefined
   }
 
-  async function upsert(input: UpsertPendingScene): Promise<PendingScene> {
+  async function upsert(
+    input: UpsertPendingScene,
+    limit: { maxPendingPerDeployer: number; isNewUpload: boolean }
+  ): Promise<PendingScene> {
     const worldName = input.worldName.toLowerCase()
+    const deployer = input.deployer.toLowerCase()
     const expiryCutoff = new Date(Date.now() - ttlMs)
 
     return await database.withAsyncContextTransaction(async () => {
+      // Per-deployer lock FIRST (acquired before the per-world lock below, a consistent order that can't
+      // deadlock). It serializes a deployer's concurrent staging requests — even to different worlds —
+      // so the concurrent-pending cap can't be raced: without it, several new uploads could each read a
+      // count below the cap and then all insert.
+      await database.query(SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_deployer:' + deployer}, 0))`)
+      if (limit.isNewUpload) {
+        const active = await countActiveByDeployer(deployer)
+        if (active >= limit.maxPendingPerDeployer) {
+          throw new InvalidRequestError(
+            `Too many partial uploads in progress for this account (max ${limit.maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+          )
+        }
+      }
+
       // Serialize the "replace overlapping + insert" critical section per world (also across
       // processes) so two concurrent uploads for the same world+parcels can't both insert.
       await database.query(SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_scenes:' + worldName}, 0))`)

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -45,10 +45,7 @@ export async function createPendingScenesManager(
     return result.rows.length > 0 ? toPendingScene(result.rows[0]) : undefined
   }
 
-  async function upsert(
-    input: UpsertPendingScene,
-    limit: { maxPendingPerDeployer: number; isNewUpload: boolean }
-  ): Promise<PendingScene> {
+  async function upsert(input: UpsertPendingScene, limit: { maxPendingPerDeployer: number }): Promise<PendingScene> {
     const worldName = input.worldName.toLowerCase()
     const deployer = input.deployer.toLowerCase()
     const expiryCutoff = new Date(Date.now() - ttlMs)
@@ -56,17 +53,9 @@ export async function createPendingScenesManager(
     return await database.withAsyncContextTransaction(async () => {
       // Per-deployer lock FIRST (acquired before the per-world lock below, a consistent order that can't
       // deadlock). It serializes a deployer's concurrent staging requests — even to different worlds —
-      // so the concurrent-pending cap can't be raced: without it, several new uploads could each read a
-      // count below the cap and then all insert.
+      // so the concurrent-pending cap (checked below, after the overlap-replace) can't be raced: without
+      // it, several new uploads could each read a count below the cap and then all insert.
       await database.query(SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_deployer:' + deployer}, 0))`)
-      if (limit.isNewUpload) {
-        const active = await countActiveByDeployer(deployer)
-        if (active >= limit.maxPendingPerDeployer) {
-          throw new InvalidRequestError(
-            `Too many partial uploads in progress for this account (max ${limit.maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
-          )
-        }
-      }
 
       // Serialize the "replace overlapping + insert" critical section per world (also across
       // processes) so two concurrent uploads for the same world+parcels can't both insert.
@@ -100,6 +89,22 @@ export async function createPendingScenesManager(
            OR (world_name = ${worldName} AND parcels && ${input.parcels}::text[] AND entity_id != ${input.entityId})
       `)
 
+      // Enforce the per-deployer concurrent-pending cap on the NET row-count change, decided here (under
+      // the deployer lock, after the overlap-replace) rather than from a stale "is this new?" flag. After
+      // this upsert the deployer will have `others + 1` non-expired rows, where `others` excludes this
+      // entity id (which contributes exactly one row whether the upsert inserts or updates). This lets a
+      // resume of the same entity — or a newer scene that replaced one of the deployer's own overlapping
+      // rows above — through without over-counting, while still capping genuinely new uploads.
+      const others = await database.query<{ count: string }>(SQL`
+        SELECT COUNT(*) AS count FROM pending_scenes
+        WHERE deployer = ${deployer} AND created_at >= ${expiryCutoff} AND entity_id != ${input.entityId}
+      `)
+      if (parseInt(others.rows[0].count, 10) + 1 > limit.maxPendingPerDeployer) {
+        throw new InvalidRequestError(
+          `Too many partial uploads in progress for this account (max ${limit.maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+        )
+      }
+
       const result = await database.query<PendingSceneRow>(SQL`
         INSERT INTO pending_scenes (entity_id, world_name, parcels, entity, deployer, created_at, updated_at)
         VALUES (${input.entityId}, ${worldName}, ${input.parcels}::text[], ${input.entity}::jsonb, ${input.deployer.toLowerCase()}, now(), now())
@@ -112,15 +117,6 @@ export async function createPendingScenesManager(
 
   async function deleteByEntityId(entityId: string): Promise<void> {
     await database.query(SQL`DELETE FROM pending_scenes WHERE entity_id = ${entityId}`)
-  }
-
-  async function countActiveByDeployer(deployer: string): Promise<number> {
-    const cutoff = new Date(Date.now() - ttlMs)
-    const result = await database.query<{ count: string }>(
-      SQL`SELECT COUNT(*) as count FROM pending_scenes
-          WHERE deployer = ${deployer.toLowerCase()} AND created_at >= ${cutoff}`
-    )
-    return parseInt(result.rows[0].count, 10)
   }
 
   async function deleteExpired(): Promise<number> {
@@ -162,5 +158,5 @@ export async function createPendingScenesManager(
     return keys
   }
 
-  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys, countActiveByDeployer }
+  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys }
 }

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -87,8 +87,14 @@ export async function createPendingScenesManager(
 
   async function getActivePendingKeys(): Promise<Set<string>> {
     const cutoff = new Date(Date.now() - ttlMs)
-    const result = await database.query<{ entity_id: string; entity: Entity }>(
-      SQL`SELECT entity_id, entity FROM pending_scenes WHERE created_at >= ${cutoff}`
+    // Project only the content hashes out of the entity JSONB instead of shipping every pending
+    // scene's full manifest: GC calls this once per delete batch, so on a large sweep the payload
+    // size matters more than the (tiny) row count.
+    const result = await database.query<{ entity_id: string; hashes: string[] | null }>(
+      SQL`SELECT entity_id,
+                 ARRAY(SELECT jsonb_array_elements(entity->'content')->>'hash') AS hashes
+          FROM pending_scenes
+          WHERE created_at >= ${cutoff}`
     )
     const keys = new Set<string>()
     for (const row of result.rows) {
@@ -96,8 +102,8 @@ export async function createPendingScenesManager(
       // referenced by the in-flight upload even though no world_scenes row exists yet.
       keys.add(row.entity_id)
       keys.add(`${row.entity_id}.auth`)
-      for (const file of row.entity.content ?? []) {
-        keys.add(file.hash)
+      for (const hash of row.hashes ?? []) {
+        keys.add(hash)
       }
     }
     return keys

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -1,0 +1,89 @@
+import SQL from 'sql-template-strings'
+import { Entity } from '@dcl/schemas'
+import { AppComponents, IPendingScenesManager, PendingScene, UpsertPendingScene } from '../types'
+
+const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+type PendingSceneRow = {
+  entity_id: string
+  world_name: string
+  parcels: string[]
+  entity: Entity
+  deployer: string
+  created_at: Date
+  updated_at: Date
+}
+
+function toPendingScene(row: PendingSceneRow): PendingScene {
+  return {
+    entityId: row.entity_id,
+    worldName: row.world_name,
+    parcels: row.parcels,
+    entity: row.entity,
+    deployer: row.deployer,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}
+
+export async function createPendingScenesManager(
+  components: Pick<AppComponents, 'config' | 'database' | 'logs'>
+): Promise<IPendingScenesManager> {
+  const { config, database, logs } = components
+  const logger = logs.getLogger('pending-scenes-manager')
+  const ttlMs = (await config.getNumber('PENDING_DEPLOYMENT_TTL')) ?? DEFAULT_PENDING_DEPLOYMENT_TTL_MS
+
+  async function getByEntityId(entityId: string): Promise<PendingScene | undefined> {
+    const cutoff = new Date(Date.now() - ttlMs)
+    const result = await database.query<PendingSceneRow>(
+      SQL`SELECT entity_id, world_name, parcels, entity, deployer, created_at, updated_at
+          FROM pending_scenes
+          WHERE entity_id = ${entityId} AND created_at >= ${cutoff}
+          LIMIT 1`
+    )
+    return result.rows.length > 0 ? toPendingScene(result.rows[0]) : undefined
+  }
+
+  async function upsert(input: UpsertPendingScene): Promise<PendingScene> {
+    const worldName = input.worldName.toLowerCase()
+    const expiryCutoff = new Date(Date.now() - ttlMs)
+
+    return await database.withAsyncContextTransaction(async () => {
+      // Serialize the "replace overlapping + insert" critical section per world (also across
+      // processes) so two concurrent uploads for the same world+parcels can't both insert.
+      await database.query(SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_scenes:' + worldName}, 0))`)
+
+      // Purge expired rows and replace any non-expired pending scene of this world whose parcels
+      // overlap the new one (a different entity id) — enforcing one pending upload per world+parcel.
+      await database.query(SQL`
+        DELETE FROM pending_scenes
+        WHERE created_at < ${expiryCutoff}
+           OR (world_name = ${worldName} AND parcels && ${input.parcels}::text[] AND entity_id != ${input.entityId})
+      `)
+
+      const result = await database.query<PendingSceneRow>(SQL`
+        INSERT INTO pending_scenes (entity_id, world_name, parcels, entity, deployer, created_at, updated_at)
+        VALUES (${input.entityId}, ${worldName}, ${input.parcels}::text[], ${input.entity}::jsonb, ${input.deployer.toLowerCase()}, now(), now())
+        ON CONFLICT (entity_id) DO UPDATE SET updated_at = now()
+        RETURNING entity_id, world_name, parcels, entity, deployer, created_at, updated_at
+      `)
+      return toPendingScene(result.rows[0])
+    })
+  }
+
+  async function deleteByEntityId(entityId: string): Promise<void> {
+    await database.query(SQL`DELETE FROM pending_scenes WHERE entity_id = ${entityId}`)
+  }
+
+  async function deleteExpired(olderThanMs: number): Promise<number> {
+    const cutoff = new Date(Date.now() - olderThanMs)
+    const result = await database.query(SQL`DELETE FROM pending_scenes WHERE created_at < ${cutoff}`)
+    const removed = result.rowCount ?? 0
+    if (removed > 0) {
+      logger.info(`Removed ${removed} expired pending scene(s)`)
+    }
+    return removed
+  }
+
+  return { getByEntityId, upsert, deleteByEntityId, deleteExpired }
+}

--- a/src/adapters/pending-scenes-manager.ts
+++ b/src/adapters/pending-scenes-manager.ts
@@ -5,6 +5,12 @@ import { AppComponents, IPendingScenesManager, PendingScene, UpsertPendingScene 
 
 const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
+// How long a finalization lease is honored before it is considered stale and can be taken over by
+// another request. Must comfortably exceed a real finalization (full validation — including the
+// external permission check — plus the deploy), so a slow-but-alive finalizer isn't pre-empted, while a
+// crashed one doesn't wedge the upload for long.
+const FINALIZATION_LEASE_TTL_MS = 2 * 60 * 1000 // 2 minutes
+
 type PendingSceneRow = {
   entity_id: string
   world_name: string
@@ -119,6 +125,32 @@ export async function createPendingScenesManager(
     await database.query(SQL`DELETE FROM pending_scenes WHERE entity_id = ${entityId}`)
   }
 
+  async function acquireFinalizationLease(entityId: string): Promise<boolean> {
+    // Atomically flip the row to FINALIZING, but only if it isn't already being finalized by a live
+    // lease. A single UPDATE ... RETURNING is the whole critical section — the row lock serializes
+    // competing acquirers — so exactly one completing request proceeds to the expensive validation +
+    // deploy; the others get `false` and back off. A lease older than the TTL (a crashed finalizer) is
+    // reclaimable.
+    const staleCutoff = new Date(Date.now() - FINALIZATION_LEASE_TTL_MS)
+    const result = await database.query(SQL`
+      UPDATE pending_scenes
+      SET status = 'FINALIZING', finalizing_at = now()
+      WHERE entity_id = ${entityId}
+        AND (status = 'UPLOADING' OR (status = 'FINALIZING' AND finalizing_at < ${staleCutoff}))
+      RETURNING entity_id
+    `)
+    return result.rowCount > 0
+  }
+
+  async function releaseFinalizationLease(entityId: string): Promise<void> {
+    // Return a still-present row to UPLOADING so a later request can finalize it. Used when a finalize
+    // attempt fails without deploying (transient error, or content reclaimed under it). A successful
+    // deploy deletes the row instead, so this no-ops there.
+    await database.query(SQL`
+      UPDATE pending_scenes SET status = 'UPLOADING', finalizing_at = NULL WHERE entity_id = ${entityId}
+    `)
+  }
+
   async function deleteExpired(): Promise<number> {
     const cutoff = new Date(Date.now() - ttlMs)
     const result = await database.query(SQL`DELETE FROM pending_scenes WHERE created_at < ${cutoff}`)
@@ -158,5 +190,13 @@ export async function createPendingScenesManager(
     return keys
   }
 
-  return { getByEntityId, upsert, deleteByEntityId, deleteExpired, getActivePendingKeys }
+  return {
+    getByEntityId,
+    upsert,
+    deleteByEntityId,
+    acquireFinalizationLease,
+    releaseFinalizationLease,
+    deleteExpired,
+    getActivePendingKeys
+  }
 }

--- a/src/adapters/pending-scenes-manager/component.ts
+++ b/src/adapters/pending-scenes-manager/component.ts
@@ -1,7 +1,8 @@
 import SQL from 'sql-template-strings'
 import { Entity } from '@dcl/schemas'
 import { InvalidRequestError } from '@dcl/http-commons'
-import { AppComponents, IPendingScenesManager, PendingScene, UpsertPendingScene } from '../types'
+import { AppComponents } from '../../types'
+import { IPendingScenesManager, PendingScene, UpsertPendingScene } from './types'
 
 const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 

--- a/src/adapters/pending-scenes-manager/index.ts
+++ b/src/adapters/pending-scenes-manager/index.ts
@@ -1,0 +1,2 @@
+export { createPendingScenesManager } from './component'
+export * from './types'

--- a/src/adapters/pending-scenes-manager/types.ts
+++ b/src/adapters/pending-scenes-manager/types.ts
@@ -1,0 +1,62 @@
+import { Entity } from '@dcl/schemas'
+
+/**
+ * A partial (multi-request) deployment being staged. Content is uploaded across several requests and
+ * the entity only becomes a live world_scenes row once every referenced file is present. Stored in a
+ * standalone `pending_scenes` table (no FK to `worlds`, so a half-uploaded world never leaks into
+ * listings). The authoritative entity *bytes* live in content storage under the entity id.
+ */
+export type PendingScene = {
+  entityId: string
+  worldName: string
+  parcels: string[]
+  entity: Entity
+  deployer: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type UpsertPendingScene = {
+  entityId: string
+  worldName: string
+  parcels: string[]
+  entity: Entity
+  deployer: string
+}
+
+export type IPendingScenesManager = {
+  /** Returns the pending scene for an entity id, treating rows past the TTL as absent. */
+  getByEntityId(entityId: string): Promise<PendingScene | undefined>
+  /**
+   * Records/refreshes a pending scene, replacing any non-expired pending scene of the same world whose
+   * parcels overlap (enforces "at most one pending upload per world+parcel"), but only when the incoming
+   * scene is newer (deployment ordering) than the overlapping ones — a strictly-newer overlapping upload
+   * causes a rejection instead. On conflict of the same entity id it only bumps updated_at so created_at
+   * (the TTL anchor) stays stable across resumes.
+   *
+   * The per-deployer concurrent-pending cap (`limit.maxPendingPerDeployer`) is enforced inside the same
+   * transaction under a per-deployer lock, on the NET row-count change (so a resume or a newer scene that
+   * replaces one of the deployer's own overlapping rows is not counted as an increase), so concurrent
+   * uploads can't race past it.
+   * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress,
+   *   or if the upsert would put the deployer over the per-deployer cap.
+   */
+  upsert(input: UpsertPendingScene, limit: { maxPendingPerDeployer: number }): Promise<PendingScene>
+  deleteByEntityId(entityId: string): Promise<void>
+  /** Deletes pending scenes older than the configured PENDING_DEPLOYMENT_TTL. Returns the number removed. */
+  deleteExpired(): Promise<number>
+  /**
+   * Returns the storage keys referenced by every non-expired pending scene: each entity id, its
+   * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
+   */
+  getActivePendingKeys(): Promise<Set<string>>
+  /**
+   * Atomically claims the finalization lease for a pending upload (flips UPLOADING → FINALIZING, or
+   * takes over a stale FINALIZING lease). Returns true if this caller holds the lease and should run the
+   * finalization; false if another request is already finalizing. Ensures only one request runs the
+   * expensive validation + deploy for a completed upload.
+   */
+  acquireFinalizationLease(entityId: string): Promise<boolean>
+  /** Releases the finalization lease (FINALIZING → UPLOADING) when a finalize attempt fails without deploying. */
+  releaseFinalizationLease(entityId: string): Promise<void>
+}

--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -29,6 +29,7 @@ import {
 } from '../types'
 import { streamToBuffer } from '@dcl/catalyst-storage'
 import { Entity, EthAddress } from '@dcl/schemas'
+import { InvalidRequestError } from '@dcl/http-commons'
 import SQL from 'sql-template-strings'
 import { buildWorldRuntimeMetadata, shouldShowInPlaces } from '../logic/world-runtime-metadata-utils'
 import { AccessSetting, defaultAccess } from '../logic/access'
@@ -228,6 +229,35 @@ export async function createWorldsManagerComponent({
     const thumbnailHash = thumbnailContent?.hash || null
 
     await database.withAsyncContextTransaction(async () => {
+      // Serialize concurrent deploys to the same world so the "reject if a newer scene already holds
+      // these parcels" check below is atomic with the soft-delete + insert. Both the vanilla and the
+      // partial-finalize paths reach deployScene, so this is the single place deployment ordering is
+      // enforced for world scenes — without the lock, a newer deploy could commit between another
+      // deploy's check and its write, and the older one would silently undeploy it.
+      await database.query(
+        SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'world_scene_deploy:' + worldName.toLowerCase()}, 0))`
+      )
+
+      // Reject if a strictly-newer scene (Decentraland ordering: greater entity.timestamp, tie broken
+      // by greater entity id) already occupies any of these parcels. This makes an older deploy — most
+      // importantly a stale partial finalize — unable to overwrite a newer one, atomically under the
+      // lock above rather than via a racy pre-write check in the caller.
+      const newer = await database.query(SQL`
+        SELECT 1 FROM world_scenes
+        WHERE world_name = ${worldName.toLowerCase()}
+          AND status = 'DEPLOYED'
+          AND parcels && ${parcels}::text[]
+          AND entity_id != ${scene.id}
+          AND ( (entity->>'timestamp')::bigint > ${scene.timestamp}
+                OR ((entity->>'timestamp')::bigint = ${scene.timestamp} AND entity_id > ${scene.id}) )
+        LIMIT 1
+      `)
+      if (newer.rowCount > 0) {
+        throw new InvalidRequestError(
+          `Deployment failed: a newer scene is already deployed on one or more of these parcels.`
+        )
+      }
+
       // Ensure world record exists, update if it does
       // On first deployment (INSERT), set settings from scene metadata
       // On subsequent deployments (UPDATE), preserve existing settings

--- a/src/adapters/worlds-manager.ts
+++ b/src/adapters/worlds-manager.ts
@@ -175,6 +175,40 @@ export async function createWorldsManagerComponent({
     return metadata
   }
 
+  // Whether a strictly-newer DEPLOYED scene (Decentraland ordering: greater entity.timestamp, tie broken
+  // by greater entity id) already occupies any of the given parcels. Shared by deployScene's atomic
+  // in-transaction guard and the public hasNewerDeployedScene fast-fail. Runs in the ambient transaction
+  // when called from within one. Parcels are expected already canonicalized.
+  async function newerDeployedSceneExists(
+    worldNameLower: string,
+    sceneId: string,
+    sceneTimestamp: number,
+    parcels: string[]
+  ): Promise<boolean> {
+    const result = await database.query(SQL`
+      SELECT 1 FROM world_scenes
+      WHERE world_name = ${worldNameLower}
+        AND status = 'DEPLOYED'
+        AND parcels && ${parcels}::text[]
+        AND entity_id != ${sceneId}
+        AND ( (entity->>'timestamp')::bigint > ${sceneTimestamp}
+              OR ((entity->>'timestamp')::bigint = ${sceneTimestamp} AND entity_id > ${sceneId}) )
+      LIMIT 1
+    `)
+    return result.rowCount > 0
+  }
+
+  // Non-authoritative fast-fail for the deploy path: lets a caller reject a stale deploy BEFORE storing
+  // its content, so a rejected older deploy doesn't leave orphaned objects in storage until GC. The
+  // authoritative, race-free check is inside deployScene (under the per-world lock).
+  async function hasNewerDeployedScene(worldName: string, scene: Entity): Promise<boolean> {
+    const parcels = coordinates.canonicalizeParcels(scene.metadata?.scene?.parcels || [])
+    if (!parcels.length) {
+      return false
+    }
+    return newerDeployedSceneExists(worldName.toLowerCase(), scene.id, scene.timestamp, parcels)
+  }
+
   /**
    * Deploys a scene to a world
    *
@@ -241,18 +275,9 @@ export async function createWorldsManagerComponent({
       // Reject if a strictly-newer scene (Decentraland ordering: greater entity.timestamp, tie broken
       // by greater entity id) already occupies any of these parcels. This makes an older deploy — most
       // importantly a stale partial finalize — unable to overwrite a newer one, atomically under the
-      // lock above rather than via a racy pre-write check in the caller.
-      const newer = await database.query(SQL`
-        SELECT 1 FROM world_scenes
-        WHERE world_name = ${worldName.toLowerCase()}
-          AND status = 'DEPLOYED'
-          AND parcels && ${parcels}::text[]
-          AND entity_id != ${scene.id}
-          AND ( (entity->>'timestamp')::bigint > ${scene.timestamp}
-                OR ((entity->>'timestamp')::bigint = ${scene.timestamp} AND entity_id > ${scene.id}) )
-        LIMIT 1
-      `)
-      if (newer.rowCount > 0) {
+      // lock above rather than via a racy pre-write check in the caller. The query runs in this
+      // transaction (ambient context), so it observes the state the lock protects.
+      if (await newerDeployedSceneExists(worldName.toLowerCase(), scene.id, scene.timestamp, parcels)) {
         throw new InvalidRequestError(
           `Deployment failed: a newer scene is already deployed on one or more of these parcels.`
         )
@@ -1160,6 +1185,7 @@ export async function createWorldsManagerComponent({
     getDeployedWorldCount,
     getMetadataForWorld,
     getEntityForWorlds,
+    hasNewerDeployedScene,
     deployScene,
     undeployScene,
     storeAccess,

--- a/src/components.ts
+++ b/src/components.ts
@@ -221,7 +221,8 @@ export async function initComponents(): Promise<AppComponents> {
 
   const pendingScenesManager = await createPendingScenesManager({ config, database, logs })
 
-  const partialDeployments = createPartialDeploymentsComponent({
+  const partialDeployments = await createPartialDeploymentsComponent({
+    config,
     coordinates,
     entityDeployer,
     limitsManager,

--- a/src/components.ts
+++ b/src/components.ts
@@ -23,6 +23,8 @@ import { createWorldsIndexerComponent } from './adapters/worlds-indexer'
 
 import { createValidator } from './logic/validations'
 import { createEntityDeployer } from './adapters/entity-deployer'
+import { createPendingScenesManager } from './adapters/pending-scenes-manager'
+import { createPartialDeploymentsComponent } from './logic/partial-deployments'
 import { createMigrationExecutor } from './adapters/migration-executor'
 import { createNameDenyListChecker } from './adapters/name-deny-list-checker'
 import { createDatabaseComponent } from './adapters/database-component'
@@ -217,6 +219,19 @@ export async function initComponents(): Promise<AppComponents> {
     worldsManager
   })
 
+  const pendingScenesManager = await createPendingScenesManager({ config, database, logs })
+
+  const partialDeployments = createPartialDeploymentsComponent({
+    coordinates,
+    entityDeployer,
+    limitsManager,
+    logs,
+    pendingScenesManager,
+    storage,
+    validator,
+    worldsManager
+  })
+
   const migrationExecutor = createMigrationExecutor({ logs, database: database, nameOwnership, storage, worldsManager })
 
   const notificationService = await createNotificationsClientComponent({ config, fetch, logs })
@@ -244,7 +259,7 @@ export async function initComponents(): Promise<AppComponents> {
 
   const worlds = createWorldsComponent({ worldsManager, snsClient })
 
-  const evictionJob = await createEvictionJob({ config, logs, worlds })
+  const evictionJob = await createEvictionJob({ config, logs, worlds, pendingScenesManager })
 
   const denyList = await createDenyListComponent({ config, fetch, logs })
   const bans = await createBansComponent({ config, fetch, logs })
@@ -302,6 +317,8 @@ export async function initComponents(): Promise<AppComponents> {
     nats,
     notificationService,
     participantKicker,
+    partialDeployments,
+    pendingScenesManager,
     peersRegistry,
     permissions,
     permissionsManager,

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -1,6 +1,7 @@
 import { Entity } from '@dcl/schemas'
 import { IHttpServerComponent } from '@dcl/core-commons'
-import { FormDataContext, readUploadedFile, toDeploymentFile } from '../../logic/multipart'
+import { bufferToStream, streamToBuffer } from '@dcl/catalyst-storage'
+import { FormDataContext, toDeploymentFile } from '../../logic/multipart'
 import { DeploymentFile, HandlerContextWithPath } from '../../types'
 import { extractAuthChain } from '../../logic/extract-auth-chain'
 import { InvalidRequestError } from '@dcl/http-commons'
@@ -19,18 +20,41 @@ function parseEntityJson(raw: string) {
 }
 
 export async function deployEntity(
-  ctx: FormDataContext & HandlerContextWithPath<'config' | 'entityDeployer' | 'storage' | 'validator', '/entities'>
+  ctx: FormDataContext &
+    HandlerContextWithPath<
+      'config' | 'entityDeployer' | 'partialDeployments' | 'pendingScenesManager' | 'storage' | 'validator',
+      '/entities'
+    >
 ): Promise<IHttpServerComponent.IResponse> {
   const entityId = requireString(ctx.formData.fields.entityId?.value[0])
   const authChain = extractAuthChain(ctx)
 
-  const entityFile = ctx.formData.files[entityId]
+  // A `partial=true` field marks a staging request of a multi-request (partial) deployment: content may
+  // be uploaded across several requests and the world only becomes live once all of it is present.
+  const isPartial = ctx.formData.fields.partial?.value[0] === 'true'
+
+  // Resolve the entity file. It must be uploaded on the first request; a later partial (resume) request
+  // may omit it, in which case it is read back from storage where the first request stored it.
+  let entityFile: DeploymentFile | undefined = ctx.formData.files[entityId]
+    ? toDeploymentFile(ctx.formData.files[entityId])
+    : undefined
+  if (!entityFile && isPartial) {
+    const stored = await ctx.components.storage.retrieve(entityId)
+    if (stored) {
+      const buf = await streamToBuffer(await stored.asStream())
+      entityFile = { size: buf.length, getStream: () => bufferToStream(buf), asBuffer: async () => buf }
+    }
+  }
   if (!entityFile) {
-    throw new InvalidRequestError(`Entity file "${entityId}" is missing from the request.`)
+    throw new InvalidRequestError(
+      isPartial
+        ? `The first partial request for an entity must include the entity file "${entityId}".`
+        : `Entity file "${entityId}" is missing from the request.`
+    )
   }
 
   // The entity JSON is small, so it is safe to read fully into memory.
-  const entityRaw = (await readUploadedFile(entityFile)).toString()
+  const entityRaw = (await entityFile.asBuffer()).toString()
   const entityMetadataJson = parseEntityJson(entityRaw)
 
   const entity: Entity = {
@@ -42,6 +66,36 @@ export async function deployEntity(
   for (const filesKey in ctx.formData.files) {
     uploadedFiles.set(filesKey, toDeploymentFile(ctx.formData.files[filesKey]))
   }
+  // Ensure the entity file is in the map even when it came from storage (partial resume request).
+  if (!uploadedFiles.has(entityId)) {
+    uploadedFiles.set(entityId, entityFile)
+  }
+
+  const baseUrl = (await ctx.components.config.getString('HTTP_BASE_URL')) || `https://${ctx.url.host}`
+
+  if (isPartial) {
+    const result = await ctx.components.partialDeployments.stage({
+      baseUrl,
+      entity,
+      entityRaw,
+      authChain,
+      files: uploadedFiles
+    })
+    if (result.complete) {
+      return {
+        status: 200,
+        body: {
+          creationTimestamp: Date.now(),
+          ...result.result
+        }
+      }
+    }
+    return { status: 202, body: { missing: result.missing ?? [] } }
+  }
+
+  // Vanilla (single-request) deployment — behaves exactly as before, plus TTL anchoring on and cleanup
+  // of any pending upload that happens to exist for this entity.
+  const pending = await ctx.components.pendingScenesManager.getByEntityId(entityId)
 
   const contentHashesInStorage = await ctx.components.storage.existMultiple(
     Array.from(new Set((entity.content || []).map(($) => $.hash)))
@@ -52,7 +106,8 @@ export async function deployEntity(
     entity,
     files: uploadedFiles,
     authChain,
-    contentHashesInStorage
+    contentHashesInStorage,
+    pendingCreatedAt: pending?.createdAt
   })
 
   if (!validationResult.ok()) {
@@ -60,7 +115,6 @@ export async function deployEntity(
   }
 
   // Store the entity
-  const baseUrl = (await ctx.components.config.getString('HTTP_BASE_URL')) || `https://${ctx.url.host}`
   const message = await ctx.components.entityDeployer.deployEntity(
     baseUrl,
     entity,
@@ -69,6 +123,9 @@ export async function deployEntity(
     entityRaw,
     authChain
   )
+
+  // A pending (partial) upload for this entity is now fully deployed; drop its staging row.
+  await ctx.components.pendingScenesManager.deleteByEntityId(entityId)
 
   return {
     status: 200,

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -6,6 +6,13 @@ import { DeploymentFile, HandlerContextWithPath } from '../../types'
 import { extractAuthChain } from '../../logic/extract-auth-chain'
 import { InvalidRequestError } from '@dcl/http-commons'
 
+// The entity file is the scene manifest (JSON): pointers, the content-hash list, and metadata — always
+// small, independent of how large the content itself is. Cap it so it can be safely read fully into
+// memory. This is important on a partial-resume request, where the entity is read back from storage and
+// its size is NOT covered by the multipart in-flight-bytes budget (the resume body is tiny), so without
+// a cap many concurrent resumes could each buffer a large stored entity and exhaust memory.
+const MAX_ENTITY_FILE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
+
 export function requireString(val: string | null | undefined): string {
   if (typeof val !== 'string') throw new InvalidRequestError('A string was expected')
   return val
@@ -39,6 +46,13 @@ export async function deployEntity(
     ? toDeploymentFile(ctx.formData.files[entityId])
     : undefined
   if (!entityFile && isPartial) {
+    // Resume request: read the entity back from storage. Check its size FIRST — the resume body is tiny
+    // so this read isn't covered by the multipart in-flight budget; buffering a large stored entity
+    // (across many concurrent resumes) would otherwise exhaust memory.
+    const storedInfo = (await ctx.components.storage.fileInfoMultiple([entityId])).get(entityId)
+    if (storedInfo && storedInfo.size !== null && storedInfo.size > MAX_ENTITY_FILE_SIZE_BYTES) {
+      throw new InvalidRequestError(`The stored entity file "${entityId}" is too large (${storedInfo.size} bytes).`)
+    }
     const stored = await ctx.components.storage.retrieve(entityId)
     if (stored) {
       const buf = await streamToBuffer(await stored.asStream())
@@ -51,6 +65,9 @@ export async function deployEntity(
         ? `The first partial request for an entity must include the entity file "${entityId}".`
         : `Entity file "${entityId}" is missing from the request.`
     )
+  }
+  if (entityFile.size > MAX_ENTITY_FILE_SIZE_BYTES) {
+    throw new InvalidRequestError(`The entity file "${entityId}" is too large (${entityFile.size} bytes).`)
   }
 
   // The entity JSON is small, so it is safe to read fully into memory.

--- a/src/controllers/handlers/deploy-entity-handler.ts
+++ b/src/controllers/handlers/deploy-entity-handler.ts
@@ -22,7 +22,7 @@ function parseEntityJson(raw: string) {
 export async function deployEntity(
   ctx: FormDataContext &
     HandlerContextWithPath<
-      'config' | 'entityDeployer' | 'partialDeployments' | 'pendingScenesManager' | 'storage' | 'validator',
+      'config' | 'entityDeployer' | 'logs' | 'partialDeployments' | 'pendingScenesManager' | 'storage' | 'validator',
       '/entities'
     >
 ): Promise<IHttpServerComponent.IResponse> {
@@ -124,8 +124,19 @@ export async function deployEntity(
     authChain
   )
 
-  // A pending (partial) upload for this entity is now fully deployed; drop its staging row.
-  await ctx.components.pendingScenesManager.deleteByEntityId(entityId)
+  // If this entity had a pending (partial) upload, it is now fully deployed via the vanilla path, so
+  // drop its staging row. Only when one exists (the common vanilla deploy has none), and best-effort:
+  // the deployment already committed, so a cleanup failure must not turn a successful deploy into a
+  // 5xx — the stale row would otherwise expire on its own via PENDING_DEPLOYMENT_TTL.
+  if (pending) {
+    try {
+      await ctx.components.pendingScenesManager.deleteByEntityId(entityId)
+    } catch (error) {
+      ctx.components.logs
+        .getLogger('deploy-entity')
+        .warn(`Failed to delete pending scene after a successful deploy: ${error}`, { entityId })
+    }
+  }
 
   return {
     status: 200,

--- a/src/controllers/handlers/garbage-collection.ts
+++ b/src/controllers/handlers/garbage-collection.ts
@@ -1,17 +1,14 @@
 import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@dcl/core-commons'
-import SQL from 'sql-template-strings'
 
 function formatSecs(millis: number): string {
   return `${(millis / 1000).toFixed(2)} secs`
 }
 
-const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
-
 export async function garbageCollectionHandler(
-  context: HandlerContextWithPath<'config' | 'database' | 'logs' | 'storage', '/gc'>
+  context: HandlerContextWithPath<'database' | 'logs' | 'pendingScenesManager' | 'storage', '/gc'>
 ): Promise<IHttpServerComponent.IResponse> {
-  const { config, database, logs, storage } = context.components
+  const { database, logs, pendingScenesManager, storage } = context.components
   const logger = logs.getLogger('garbage-collection')
 
   async function getAllActiveKeys() {
@@ -49,23 +46,10 @@ export async function garbageCollectionHandler(
     })
 
     // Non-expired partial (pending) deployments: their entity id, auth-chain key, and content hashes
-    // are still referenced even though no world_scenes row exists yet. Cutoff-filtered so staged content
-    // becomes reclaimable exactly when the pending upload expires, even if the eviction job lags.
-    const pendingTtlMs = (await config.getNumber('PENDING_DEPLOYMENT_TTL')) ?? DEFAULT_PENDING_DEPLOYMENT_TTL_MS
-    const cutoff = new Date(Date.now() - pendingTtlMs)
-    const pendingResult = await database.query<{
-      entity_id: string
-      entity: { content?: Array<{ hash: string }> }
-    }>(SQL`SELECT entity_id, entity FROM pending_scenes WHERE created_at >= ${cutoff}`)
-    pendingResult.rows.forEach((row) => {
-      activeKeys.add(row.entity_id)
-      activeKeys.add(`${row.entity_id}.auth`)
-      if (row.entity.content) {
-        for (const file of row.entity.content) {
-          activeKeys.add(file.hash)
-        }
-      }
-    })
+    // are still referenced even though no world_scenes row exists yet.
+    for (const key of await pendingScenesManager.getActivePendingKeys()) {
+      activeKeys.add(key)
+    }
 
     logger.info(`Done in ${formatSecs(Date.now() - start)}. Database contains ${activeKeys.size} active keys.`)
 
@@ -80,23 +64,36 @@ export async function garbageCollectionHandler(
   const start = Date.now()
   let totalRemovedKeys = 0
   const batch = new Set<string>()
+
+  // Re-check right before deleting: the activeKeys snapshot was taken once, but partial uploads
+  // stage content across a long window and one can START mid-sweep (its pending row is written just
+  // before its content). Subtracting the CURRENT pending keys from each batch keeps a freshly-staged
+  // upload's content from being reclaimed while the sweep is in flight. pending_scenes is tiny, so
+  // this re-query per batch is cheap.
+  const deleteBatch = async (keys: Set<string>): Promise<void> => {
+    const pendingNow = await pendingScenesManager.getActivePendingKeys()
+    const toDelete = [...keys].filter((key) => !pendingNow.has(key))
+    if (toDelete.length === 0) {
+      return
+    }
+    logger.info(`Deleting a batch of ${toDelete.length} keys from storage...`)
+    await storage.delete(toDelete)
+    totalRemovedKeys += toDelete.length
+  }
+
   for await (const key of storage.allFileIds()) {
     if (!activeKeys.has(key)) {
       batch.add(key)
     }
 
     if (batch.size === 1000) {
-      logger.info(`Deleting a batch of ${batch.size} keys from storage...`)
-      await storage.delete([...batch])
-      totalRemovedKeys += batch.size
+      await deleteBatch(batch)
       batch.clear()
     }
   }
 
   if (batch.size > 0) {
-    logger.info(`Deleting a batch of ${batch.size} keys from storage...`)
-    await storage.delete([...batch])
-    totalRemovedKeys += batch.size
+    await deleteBatch(batch)
   }
   logger.info(
     `Done in ${formatSecs(Date.now() - start)}. Deleted ${totalRemovedKeys} keys that are not active in the storage.`

--- a/src/controllers/handlers/garbage-collection.ts
+++ b/src/controllers/handlers/garbage-collection.ts
@@ -1,14 +1,17 @@
 import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@dcl/core-commons'
+import SQL from 'sql-template-strings'
 
 function formatSecs(millis: number): string {
   return `${(millis / 1000).toFixed(2)} secs`
 }
 
+const DEFAULT_PENDING_DEPLOYMENT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
 export async function garbageCollectionHandler(
-  context: HandlerContextWithPath<'database' | 'logs' | 'storage', '/gc'>
+  context: HandlerContextWithPath<'config' | 'database' | 'logs' | 'storage', '/gc'>
 ): Promise<IHttpServerComponent.IResponse> {
-  const { database, logs, storage } = context.components
+  const { config, database, logs, storage } = context.components
   const logger = logs.getLogger('garbage-collection')
 
   async function getAllActiveKeys() {
@@ -43,6 +46,25 @@ export async function garbageCollectionHandler(
     )
     thumbnailsResult.rows.forEach((row) => {
       activeKeys.add(row.thumbnail_hash)
+    })
+
+    // Non-expired partial (pending) deployments: their entity id, auth-chain key, and content hashes
+    // are still referenced even though no world_scenes row exists yet. Cutoff-filtered so staged content
+    // becomes reclaimable exactly when the pending upload expires, even if the eviction job lags.
+    const pendingTtlMs = (await config.getNumber('PENDING_DEPLOYMENT_TTL')) ?? DEFAULT_PENDING_DEPLOYMENT_TTL_MS
+    const cutoff = new Date(Date.now() - pendingTtlMs)
+    const pendingResult = await database.query<{
+      entity_id: string
+      entity: { content?: Array<{ hash: string }> }
+    }>(SQL`SELECT entity_id, entity FROM pending_scenes WHERE created_at >= ${cutoff}`)
+    pendingResult.rows.forEach((row) => {
+      activeKeys.add(row.entity_id)
+      activeKeys.add(`${row.entity_id}.auth`)
+      if (row.entity.content) {
+        for (const file of row.entity.content) {
+          activeKeys.add(file.hash)
+        }
+      }
     })
 
     logger.info(`Done in ${formatSecs(Date.now() - start)}. Database contains ${activeKeys.size} active keys.`)

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -154,7 +154,7 @@ export async function createPartialDeploymentsComponent(
     // preserves created_at, so the TTL anchor stays stable across resumes.)
     const pendingRow = await pendingScenesManager.upsert(
       { entityId: entity.id, worldName, parcels, entity, deployer },
-      { maxPendingPerDeployer, isNewUpload: !pending }
+      { maxPendingPerDeployer }
     )
 
     // Store this batch's files (content-addressed, so concurrent identical writes are idempotent).
@@ -185,8 +185,21 @@ export async function createPartialDeploymentsComponent(
     // atomically under a per-world lock (rejecting an older deploy that would overwrite a newer scene),
     // so a separate check would be both racy and redundant. The early assertNoNewerDeployment above is
     // kept only as a fast-fail for new uploads.
+
+    // Re-verify content presence immediately before the deploy commits. The completeness check above ran
+    // before the (slow) full validation, and a garbage-collection sweep could have reclaimed a reused,
+    // already-stored file in that window (the pending row protects content, but a GC batch whose
+    // snapshot predates this row would not see it). Committing a scene that references deleted content
+    // would corrupt it, so if anything is missing now, return incomplete and let the client re-upload —
+    // this shrinks the DB-row-vs-object-storage window to the gap between this check and the commit.
+    const stillPresent = await storage.existMultiple(contentHashes)
+    const nowMissing = contentHashes.filter((hash) => !stillPresent.get(hash))
+    if (nowMissing.length > 0) {
+      return { complete: false, missing: nowMissing }
+    }
+
     try {
-      const result = await entityDeployer.deployEntity(baseUrl, entity, present, files, entityRaw, authChain)
+      const result = await entityDeployer.deployEntity(baseUrl, entity, stillPresent, files, entityRaw, authChain)
       await pendingScenesManager.deleteByEntityId(entity.id)
       return { complete: true, result }
     } catch (error) {

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,12 +1,7 @@
 import { Entity } from '@dcl/schemas'
 import { InvalidRequestError } from '@dcl/http-commons'
-import {
-  AppComponents,
-  DeploymentFile,
-  IPartialDeploymentsComponent,
-  StageDeploymentInput,
-  StageDeploymentResult
-} from '../../types'
+import { AppComponents, DeploymentFile } from '../../types'
+import { IPartialDeploymentsComponent, StageDeploymentInput, StageDeploymentResult } from './types'
 
 // How many content files to store to storage at once. They are independent content-addressed objects,
 // so storing them concurrently (rather than one awaited PUT at a time) keeps a large batch fast.

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -79,13 +79,23 @@ export function createPartialDeploymentsComponent(
 
     // Content-independent validations (structure, signature, scene rules, permission), anchoring the
     // deployment-TTL check on when the upload started when a pending row already exists.
-    const stagingValidation = await validator.validateStaging({
-      entity,
-      files,
-      authChain,
-      contentHashesInStorage,
-      pendingCreatedAt: pending?.createdAt
-    })
+    //
+    // Resume batches skip the slow external permission check, but only when the signer is the deployer
+    // who created the pending record: that creation required passing the check, every uploaded byte is
+    // hash-verified against the staged manifest, and finalize re-runs the full validation (including
+    // permission) before going live. Any other signer goes through the full staging validation, so a
+    // third party can't ride an existing upload's fast path.
+    const isResumeBySameDeployer = !!pending && pending.deployer === authChain[0].payload.toLowerCase()
+    const stagingValidation = await validator.validateStaging(
+      {
+        entity,
+        files,
+        authChain,
+        contentHashesInStorage,
+        pendingCreatedAt: pending?.createdAt
+      },
+      { skipPermissionCheck: isResumeBySameDeployer }
+    )
     if (!stagingValidation.ok()) {
       throw new InvalidRequestError(`Deployment failed: ${stagingValidation.errors.join(', ')}`)
     }
@@ -112,9 +122,12 @@ export function createPartialDeploymentsComponent(
       )
     }
 
-    // Record/refresh the pending scene BEFORE storing files, so staged content is protected from the
-    // garbage collector as soon as it lands. Replaces any overlapping pending upload of this world.
-    const upserted = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
+    // Record/refresh the pending scene on EVERY batch, always BEFORE storing files: it is what protects
+    // the staged content from the garbage collector, and re-asserting it per batch resurrects the row
+    // if a competing overlapping upload replaced it between requests — otherwise this batch's files
+    // would be written with no GC protection for the remainder of the upload. (On conflict the upsert
+    // preserves created_at, so the TTL anchor stays stable across resumes.)
+    const pendingRow = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
 
     // Store this batch's files (content-addressed, so concurrent identical writes are idempotent),
     // skipping content already stored. The entity JSON (keyed by entity.id, not in contentHashes) is
@@ -130,20 +143,22 @@ export function createPartialDeploymentsComponent(
       return { complete: false, missing }
     }
 
-    // Everything is present — re-check for a newer deployment (one may have landed while this upload was
-    // in flight) and run the full validation before deploying in this same request.
-    await assertNoNewerDeployment(worldName, entity, parcels)
-
+    // Everything is present — run the full validation before deploying in this same request.
     const fullValidation = await validator.validate({
       entity,
       files,
       authChain,
       contentHashesInStorage: present,
-      pendingCreatedAt: upserted.createdAt
+      pendingCreatedAt: pendingRow.createdAt
     })
     if (!fullValidation.ok()) {
       throw new InvalidRequestError(`Deployment failed: ${fullValidation.errors.join(', ')}`)
     }
+
+    // Re-check for a newer deployment immediately before the write — AFTER the slow full validation —
+    // so the window between the check and deployScene's last-write-wins transaction is as small as
+    // possible (a newer vanilla deploy landing inside that window would be silently undeployed).
+    await assertNoNewerDeployment(worldName, entity, parcels)
 
     try {
       const result = await entityDeployer.deployEntity(baseUrl, entity, present, files, entityRaw, authChain)

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -54,11 +54,14 @@ export function createPartialDeploymentsComponent(
     }
   }
 
-  async function storeFiles(
-    files: Map<string, DeploymentFile>,
-    alreadyStored: (hash: string) => boolean
-  ): Promise<void> {
-    const toStore = Array.from(files).filter(([hash]) => !alreadyStored(hash))
+  async function storeFiles(files: Map<string, DeploymentFile>): Promise<void> {
+    // Store every file the client sent this batch, in bounded-parallel batches. We do NOT skip files a
+    // pre-request snapshot said were already stored: that snapshot predates the pending row (and its GC
+    // protection), so a file present then could be swept before we store, and skipping it would discard
+    // bytes uploaded in this very batch. Storage is content-addressed (re-store is an idempotent no-op)
+    // and the client already omits files reported by /available-content, so this rarely re-sends
+    // present content anyway.
+    const toStore = Array.from(files)
     for (let i = 0; i < toStore.length; i += STORE_CONCURRENCY) {
       await Promise.all(
         toStore.slice(i, i + STORE_CONCURRENCY).map(([hash, file]) => storage.storeStream(hash, file.getStream()))
@@ -134,10 +137,8 @@ export function createPartialDeploymentsComponent(
     // preserves created_at, so the TTL anchor stays stable across resumes.)
     const pendingRow = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
 
-    // Store this batch's files (content-addressed, so concurrent identical writes are idempotent),
-    // skipping content already stored. The entity JSON (keyed by entity.id, not in contentHashes) is
-    // small and always (re)stored, which covers the first request.
-    await storeFiles(files, (hash) => hash !== entity.id && storedInfo.get(hash) !== undefined)
+    // Store this batch's files (content-addressed, so concurrent identical writes are idempotent).
+    await storeFiles(files)
 
     // Completeness must be a fresh read, not derived from the start-of-request snapshot: a concurrent
     // partial request for the same entity may have stored the remaining files while this one ran, and

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -125,20 +125,11 @@ export async function createPartialDeploymentsComponent(
     const deployer = authChain[0].payload
 
     // Reject a NEW upload early (before it replaces any pending state) if a newer scene already holds
-    // these parcels. Resume batches skip this: they never deploy by themselves — the pre-finalize
-    // re-check right before deployScene is the load-bearing guard — so re-querying world_scenes on
-    // every intermediate batch would be wasted work.
+    // these parcels. Fast-fail only: deployScene enforces ordering atomically at finalize. Resume
+    // batches skip it (they never deploy by themselves) to avoid a per-batch world_scenes query.
+    // (The per-deployer concurrent-pending cap is enforced atomically inside upsert below.)
     if (!pending) {
       await assertNoNewerDeployment(worldName, entity, parcels)
-
-      // Cap concurrent staged uploads per deployer so one account can't pin storage across many
-      // worlds/parcel-sets for the full TTL. Only NEW uploads count — a resume reuses an existing slot.
-      const activePending = await pendingScenesManager.countActiveByDeployer(deployer)
-      if (activePending >= maxPendingPerDeployer) {
-        throw new InvalidRequestError(
-          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
-        )
-      }
     }
 
     // Cumulative size budget: uploaded bytes for this batch + stored sizes for earlier batches. Checked
@@ -161,7 +152,10 @@ export async function createPartialDeploymentsComponent(
     // if a competing overlapping upload replaced it between requests — otherwise this batch's files
     // would be written with no GC protection for the remainder of the upload. (On conflict the upsert
     // preserves created_at, so the TTL anchor stays stable across resumes.)
-    const pendingRow = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
+    const pendingRow = await pendingScenesManager.upsert(
+      { entityId: entity.id, worldName, parcels, entity, deployer },
+      { maxPendingPerDeployer, isNewUpload: !pending }
+    )
 
     // Store this batch's files (content-addressed, so concurrent identical writes are idempotent).
     await storeFiles(files)
@@ -187,11 +181,10 @@ export async function createPartialDeploymentsComponent(
       throw new InvalidRequestError(`Deployment failed: ${fullValidation.errors.join(', ')}`)
     }
 
-    // Re-check for a newer deployment immediately before the write — AFTER the slow full validation —
-    // so the window between the check and deployScene's last-write-wins transaction is as small as
-    // possible (a newer vanilla deploy landing inside that window would be silently undeployed).
-    await assertNoNewerDeployment(worldName, entity, parcels)
-
+    // No pre-write newer-deployment re-check here: deployScene now enforces deployment ordering
+    // atomically under a per-world lock (rejecting an older deploy that would overwrite a newer scene),
+    // so a separate check would be both racy and redundant. The early assertNoNewerDeployment above is
+    // kept only as a fast-fail for new uploads.
     try {
       const result = await entityDeployer.deployEntity(baseUrl, entity, present, files, entityRaw, authChain)
       await pendingScenesManager.deleteByEntityId(entity.id)

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,5 +1,16 @@
+import { Entity } from '@dcl/schemas'
 import { InvalidRequestError } from '@dcl/http-commons'
-import { AppComponents, IPartialDeploymentsComponent, StageDeploymentInput, StageDeploymentResult } from '../../types'
+import {
+  AppComponents,
+  DeploymentFile,
+  IPartialDeploymentsComponent,
+  StageDeploymentInput,
+  StageDeploymentResult
+} from '../../types'
+
+// How many content files to store to storage at once. They are independent content-addressed objects,
+// so storing them concurrently (rather than one awaited PUT at a time) keeps a large batch fast.
+const STORE_CONCURRENCY = 10
 
 function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
@@ -22,12 +33,49 @@ export function createPartialDeploymentsComponent(
     components
   const logger = logs.getLogger('partial-deployments')
 
+  /**
+   * Rejects the deployment if a strictly-newer scene already occupies any of these parcels. "Newer"
+   * follows the deployment ordering used across Decentraland: greater entity timestamp, breaking ties
+   * by greater entity id. Without this a stale pending upload (its TTL anchored on when it started,
+   * up to 24h ago) could finalize and silently overwrite a newer scene deployed while it was in flight.
+   */
+  async function assertNoNewerDeployment(worldName: string, entity: Entity, parcels: string[]): Promise<void> {
+    const { scenes } = await worldsManager.getWorldScenes({ worldName, coordinates: parcels })
+    const newer = scenes.find(
+      (scene) =>
+        scene.entityId !== entity.id &&
+        (scene.entity.timestamp > entity.timestamp ||
+          (scene.entity.timestamp === entity.timestamp && scene.entityId > entity.id))
+    )
+    if (newer) {
+      throw new InvalidRequestError(
+        `Deployment failed: a newer scene (${newer.entityId}) is already deployed on one or more of these parcels.`
+      )
+    }
+  }
+
+  async function storeFiles(
+    files: Map<string, DeploymentFile>,
+    alreadyStored: (hash: string) => boolean
+  ): Promise<void> {
+    const toStore = Array.from(files).filter(([hash]) => !alreadyStored(hash))
+    for (let i = 0; i < toStore.length; i += STORE_CONCURRENCY) {
+      await Promise.all(
+        toStore.slice(i, i + STORE_CONCURRENCY).map(([hash, file]) => storage.storeStream(hash, file.getStream()))
+      )
+    }
+  }
+
   async function stage(input: StageDeploymentInput): Promise<StageDeploymentResult> {
     const { baseUrl, entity, entityRaw, authChain, files } = input
     const contentHashes = Array.from(new Set((entity.content ?? []).map((c) => c.hash)))
 
     const pending = await pendingScenesManager.getByEntityId(entity.id)
-    const contentHashesInStorage = await storage.existMultiple(contentHashes)
+
+    // Single storage metadata lookup over the referenced content: presence is `info !== undefined`
+    // and size is `info.size`, so this subsumes a separate existence probe.
+    const storedInfo = await storage.fileInfoMultiple(contentHashes)
+    const contentHashesInStorage = new Map(contentHashes.map((hash) => [hash, storedInfo.get(hash) !== undefined]))
 
     // Content-independent validations (structure, signature, scene rules, permission), anchoring the
     // deployment-TTL check on when the upload started when a pending row already exists.
@@ -46,14 +94,12 @@ export function createPartialDeploymentsComponent(
     const parcels = Array.from(new Set(coordinates.canonicalizeParcels(entity.pointers)))
     const deployer = authChain[0].payload
 
-    // Record/refresh the pending scene BEFORE storing files, so staged content is protected from the
-    // garbage collector as soon as it lands. Replaces any overlapping pending upload of this world.
-    const upserted = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
+    // Reject early (before touching any pending state) if a newer scene already holds these parcels.
+    await assertNoNewerDeployment(worldName, entity, parcels)
 
     // Cumulative size budget: uploaded bytes for this batch + stored sizes for earlier batches. Checked
-    // before storing this batch so an over-budget upload is never persisted (its row is dropped, and
-    // any earlier staged content becomes reclaimable by GC once the row is gone).
-    const storedInfo = await storage.fileInfoMultiple(contentHashes)
+    // BEFORE the upsert below, because upsert's overlap-replace destroys any other in-flight upload of
+    // this world — an over-budget request must not take another deployer's pending upload down with it.
     let totalSize = 0
     for (const hash of contentHashes) {
       const uploaded = files.get(hash)
@@ -61,30 +107,33 @@ export function createPartialDeploymentsComponent(
     }
     const maxSize = await limitsManager.getMaxAllowedSizeInBytesFor(worldName, parcels)
     if (BigInt(totalSize) > maxSize) {
-      await pendingScenesManager.deleteByEntityId(entity.id)
       throw new InvalidRequestError(
         `Deployment failed: The deployment is too big. The maximum total size allowed is ${maxSize} bytes for scenes but you tried to upload ${totalSize}.`
       )
     }
 
-    // Store this batch's files (content-addressed, so concurrent identical writes are idempotent),
-    // skipping anything already stored. This also stores the entity JSON on the first request.
-    const uploadedKeys = Array.from(files.keys())
-    const alreadyStored = await storage.existMultiple(uploadedKeys)
-    for (const [hash, file] of files) {
-      if (!alreadyStored.get(hash)) {
-        await storage.storeStream(hash, file.getStream())
-      }
-    }
+    // Record/refresh the pending scene BEFORE storing files, so staged content is protected from the
+    // garbage collector as soon as it lands. Replaces any overlapping pending upload of this world.
+    const upserted = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
 
-    // Completeness: if any referenced content is still missing, keep waiting for more requests.
+    // Store this batch's files (content-addressed, so concurrent identical writes are idempotent),
+    // skipping content already stored. The entity JSON (keyed by entity.id, not in contentHashes) is
+    // small and always (re)stored, which covers the first request.
+    await storeFiles(files, (hash) => hash !== entity.id && storedInfo.get(hash) !== undefined)
+
+    // Completeness must be a fresh read, not derived from the start-of-request snapshot: a concurrent
+    // partial request for the same entity may have stored the remaining files while this one ran, and
+    // whichever request observes the full set is the one that finalizes.
     const present = await storage.existMultiple(contentHashes)
     const missing = contentHashes.filter((hash) => !present.get(hash))
     if (missing.length > 0) {
       return { complete: false, missing }
     }
 
-    // Everything is present — run the full validation and deploy in this same request.
+    // Everything is present — re-check for a newer deployment (one may have landed while this upload was
+    // in flight) and run the full validation before deploying in this same request.
+    await assertNoNewerDeployment(worldName, entity, parcels)
+
     const fullValidation = await validator.validate({
       entity,
       files,

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -104,8 +104,13 @@ export function createPartialDeploymentsComponent(
     const parcels = Array.from(new Set(coordinates.canonicalizeParcels(entity.pointers)))
     const deployer = authChain[0].payload
 
-    // Reject early (before touching any pending state) if a newer scene already holds these parcels.
-    await assertNoNewerDeployment(worldName, entity, parcels)
+    // Reject a NEW upload early (before it replaces any pending state) if a newer scene already holds
+    // these parcels. Resume batches skip this: they never deploy by themselves — the pre-finalize
+    // re-check right before deployScene is the load-bearing guard — so re-querying world_scenes on
+    // every intermediate batch would be wasted work.
+    if (!pending) {
+      await assertNoNewerDeployment(worldName, entity, parcels)
+    }
 
     // Cumulative size budget: uploaded bytes for this batch + stored sizes for earlier batches. Checked
     // BEFORE the upsert below, because upsert's overlap-replace destroys any other in-flight upload of

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -16,9 +16,15 @@ function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
 }
 
-export function createPartialDeploymentsComponent(
+// Default cap on the number of concurrent non-expired pending uploads a single deployer may have in
+// flight. Bounds the storage a deployer can pin at once (each upload is already bounded by the
+// per-world size limit) without throttling legitimate parallel deploys. Override via config.
+const DEFAULT_MAX_PENDING_PER_DEPLOYER = 10
+
+export async function createPartialDeploymentsComponent(
   components: Pick<
     AppComponents,
+    | 'config'
     | 'coordinates'
     | 'entityDeployer'
     | 'limitsManager'
@@ -28,10 +34,21 @@ export function createPartialDeploymentsComponent(
     | 'validator'
     | 'worldsManager'
   >
-): IPartialDeploymentsComponent {
-  const { coordinates, entityDeployer, limitsManager, logs, pendingScenesManager, storage, validator, worldsManager } =
-    components
+): Promise<IPartialDeploymentsComponent> {
+  const {
+    config,
+    coordinates,
+    entityDeployer,
+    limitsManager,
+    logs,
+    pendingScenesManager,
+    storage,
+    validator,
+    worldsManager
+  } = components
   const logger = logs.getLogger('partial-deployments')
+  const maxPendingPerDeployer =
+    (await config.getNumber('MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER')) ?? DEFAULT_MAX_PENDING_PER_DEPLOYER
 
   /**
    * Rejects the deployment if a strictly-newer scene already occupies any of these parcels. "Newer"
@@ -113,6 +130,15 @@ export function createPartialDeploymentsComponent(
     // every intermediate batch would be wasted work.
     if (!pending) {
       await assertNoNewerDeployment(worldName, entity, parcels)
+
+      // Cap concurrent staged uploads per deployer so one account can't pin storage across many
+      // worlds/parcel-sets for the full TTL. Only NEW uploads count — a resume reuses an existing slot.
+      const activePending = await pendingScenesManager.countActiveByDeployer(deployer)
+      if (activePending >= maxPendingPerDeployer) {
+        throw new InvalidRequestError(
+          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+        )
+      }
     }
 
     // Cumulative size budget: uploaded bytes for this batch + stored sizes for earlier batches. Checked

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,0 +1,122 @@
+import { InvalidRequestError } from '@dcl/http-commons'
+import { AppComponents, IPartialDeploymentsComponent, StageDeploymentInput, StageDeploymentResult } from '../../types'
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
+}
+
+export function createPartialDeploymentsComponent(
+  components: Pick<
+    AppComponents,
+    | 'coordinates'
+    | 'entityDeployer'
+    | 'limitsManager'
+    | 'logs'
+    | 'pendingScenesManager'
+    | 'storage'
+    | 'validator'
+    | 'worldsManager'
+  >
+): IPartialDeploymentsComponent {
+  const { coordinates, entityDeployer, limitsManager, logs, pendingScenesManager, storage, validator, worldsManager } =
+    components
+  const logger = logs.getLogger('partial-deployments')
+
+  async function stage(input: StageDeploymentInput): Promise<StageDeploymentResult> {
+    const { baseUrl, entity, entityRaw, authChain, files } = input
+    const contentHashes = Array.from(new Set((entity.content ?? []).map((c) => c.hash)))
+
+    const pending = await pendingScenesManager.getByEntityId(entity.id)
+    const contentHashesInStorage = await storage.existMultiple(contentHashes)
+
+    // Content-independent validations (structure, signature, scene rules, permission), anchoring the
+    // deployment-TTL check on when the upload started when a pending row already exists.
+    const stagingValidation = await validator.validateStaging({
+      entity,
+      files,
+      authChain,
+      contentHashesInStorage,
+      pendingCreatedAt: pending?.createdAt
+    })
+    if (!stagingValidation.ok()) {
+      throw new InvalidRequestError(`Deployment failed: ${stagingValidation.errors.join(', ')}`)
+    }
+
+    const worldName = entity.metadata.worldConfiguration.name.toLowerCase()
+    const parcels = Array.from(new Set(coordinates.canonicalizeParcels(entity.pointers)))
+    const deployer = authChain[0].payload
+
+    // Record/refresh the pending scene BEFORE storing files, so staged content is protected from the
+    // garbage collector as soon as it lands. Replaces any overlapping pending upload of this world.
+    const upserted = await pendingScenesManager.upsert({ entityId: entity.id, worldName, parcels, entity, deployer })
+
+    // Cumulative size budget: uploaded bytes for this batch + stored sizes for earlier batches. Checked
+    // before storing this batch so an over-budget upload is never persisted (its row is dropped, and
+    // any earlier staged content becomes reclaimable by GC once the row is gone).
+    const storedInfo = await storage.fileInfoMultiple(contentHashes)
+    let totalSize = 0
+    for (const hash of contentHashes) {
+      const uploaded = files.get(hash)
+      totalSize += uploaded ? uploaded.size : (storedInfo.get(hash)?.size ?? 0)
+    }
+    const maxSize = await limitsManager.getMaxAllowedSizeInBytesFor(worldName, parcels)
+    if (BigInt(totalSize) > maxSize) {
+      await pendingScenesManager.deleteByEntityId(entity.id)
+      throw new InvalidRequestError(
+        `Deployment failed: The deployment is too big. The maximum total size allowed is ${maxSize} bytes for scenes but you tried to upload ${totalSize}.`
+      )
+    }
+
+    // Store this batch's files (content-addressed, so concurrent identical writes are idempotent),
+    // skipping anything already stored. This also stores the entity JSON on the first request.
+    const uploadedKeys = Array.from(files.keys())
+    const alreadyStored = await storage.existMultiple(uploadedKeys)
+    for (const [hash, file] of files) {
+      if (!alreadyStored.get(hash)) {
+        await storage.storeStream(hash, file.getStream())
+      }
+    }
+
+    // Completeness: if any referenced content is still missing, keep waiting for more requests.
+    const present = await storage.existMultiple(contentHashes)
+    const missing = contentHashes.filter((hash) => !present.get(hash))
+    if (missing.length > 0) {
+      return { complete: false, missing }
+    }
+
+    // Everything is present — run the full validation and deploy in this same request.
+    const fullValidation = await validator.validate({
+      entity,
+      files,
+      authChain,
+      contentHashesInStorage: present,
+      pendingCreatedAt: upserted.createdAt
+    })
+    if (!fullValidation.ok()) {
+      throw new InvalidRequestError(`Deployment failed: ${fullValidation.errors.join(', ')}`)
+    }
+
+    try {
+      const result = await entityDeployer.deployEntity(baseUrl, entity, present, files, entityRaw, authChain)
+      await pendingScenesManager.deleteByEntityId(entity.id)
+      return { complete: true, result }
+    } catch (error) {
+      // Concurrent finalize: another request completing the same upload won the world_scenes PK insert.
+      // If the scene is now deployed, treat this request as an idempotent success.
+      if (isUniqueViolation(error)) {
+        const existing = await worldsManager.getWorldScenes({ worldName, entityId: entity.id }, { limit: 1 })
+        if (existing.scenes.length > 0) {
+          await pendingScenesManager.deleteByEntityId(entity.id)
+          logger.info(`Partial deployment finalized concurrently; returning idempotent success`, {
+            entityId: entity.id,
+            worldName
+          })
+          return { complete: true, result: { message: `Your scene was deployed to World "${worldName}".` } }
+        }
+      }
+      throw error
+    }
+  }
+
+  return { stage }
+}

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -169,42 +169,59 @@ export async function createPartialDeploymentsComponent(
       return { complete: false, missing }
     }
 
-    // Everything is present — run the full validation before deploying in this same request.
-    const fullValidation = await validator.validate({
-      entity,
-      files,
-      authChain,
-      contentHashesInStorage: present,
-      pendingCreatedAt: pendingRow.createdAt
-    })
-    if (!fullValidation.ok()) {
-      throw new InvalidRequestError(`Deployment failed: ${fullValidation.errors.join(', ')}`)
-    }
-
-    // No pre-write newer-deployment re-check here: deployScene now enforces deployment ordering
-    // atomically under a per-world lock (rejecting an older deploy that would overwrite a newer scene),
-    // so a separate check would be both racy and redundant. The early assertNoNewerDeployment above is
-    // kept only as a fast-fail for new uploads.
-
-    // Re-verify content presence immediately before the deploy commits. The completeness check above ran
-    // before the (slow) full validation, and a garbage-collection sweep could have reclaimed a reused,
-    // already-stored file in that window (the pending row protects content, but a GC batch whose
-    // snapshot predates this row would not see it). Committing a scene that references deleted content
-    // would corrupt it, so if anything is missing now, return incomplete and let the client re-upload —
-    // this shrinks the DB-row-vs-object-storage window to the gap between this check and the commit.
-    const stillPresent = await storage.existMultiple(contentHashes)
-    const nowMissing = contentHashes.filter((hash) => !stillPresent.get(hash))
-    if (nowMissing.length > 0) {
-      return { complete: false, missing: nowMissing }
+    // Everything is present — claim the finalization lease so only ONE request runs the expensive
+    // validation + deploy for this completed upload (the client's parallel worker pool and retries mean
+    // several completing requests can arrive at once).
+    const gotLease = await pendingScenesManager.acquireFinalizationLease(entity.id)
+    if (!gotLease) {
+      // Another request is finalizing (or already did). If the scene is live now, report the idempotent
+      // success; otherwise report not-yet-complete so the client backs off and retries — it converges
+      // once the winner finishes (or its lease expires and this request can take over).
+      const existing = await worldsManager.getWorldScenes({ worldName, entityId: entity.id }, { limit: 1 })
+      if (existing.scenes.length > 0) {
+        await pendingScenesManager.deleteByEntityId(entity.id).catch(() => undefined)
+        return { complete: true, result: { message: `Your scene was deployed to World "${worldName}".` } }
+      }
+      return { complete: false, missing: [] }
     }
 
     try {
+      // Run the full validation before deploying, in this same request.
+      const fullValidation = await validator.validate({
+        entity,
+        files,
+        authChain,
+        contentHashesInStorage: present,
+        pendingCreatedAt: pendingRow.createdAt
+      })
+      if (!fullValidation.ok()) {
+        throw new InvalidRequestError(`Deployment failed: ${fullValidation.errors.join(', ')}`)
+      }
+
+      // No pre-write newer-deployment re-check here: deployScene enforces deployment ordering atomically
+      // under a per-world lock (rejecting an older deploy that would overwrite a newer scene), so a
+      // separate check would be both racy and redundant. The early assertNoNewerDeployment above is kept
+      // only as a fast-fail for new uploads.
+
+      // Re-verify content presence immediately before the deploy commits. The completeness check above
+      // ran before the (slow) full validation, and a garbage-collection sweep could have reclaimed a
+      // reused, already-stored file in that window (the pending row protects content, but a GC batch
+      // whose snapshot predates this row would not see it). Committing a scene that references deleted
+      // content would corrupt it, so if anything is missing now, release the lease and return incomplete
+      // so the client re-uploads — shrinking the DB-row-vs-object-storage window to check-to-commit.
+      const stillPresent = await storage.existMultiple(contentHashes)
+      const nowMissing = contentHashes.filter((hash) => !stillPresent.get(hash))
+      if (nowMissing.length > 0) {
+        await pendingScenesManager.releaseFinalizationLease(entity.id)
+        return { complete: false, missing: nowMissing }
+      }
+
       const result = await entityDeployer.deployEntity(baseUrl, entity, stillPresent, files, entityRaw, authChain)
       await pendingScenesManager.deleteByEntityId(entity.id)
       return { complete: true, result }
     } catch (error) {
-      // Concurrent finalize: another request completing the same upload won the world_scenes PK insert.
-      // If the scene is now deployed, treat this request as an idempotent success.
+      // Concurrent finalize: another request won the world_scenes PK insert (e.g. a stale lease was taken
+      // over by two requests). If the scene is now deployed, treat this request as an idempotent success.
       if (isUniqueViolation(error)) {
         const existing = await worldsManager.getWorldScenes({ worldName, entityId: entity.id }, { limit: 1 })
         if (existing.scenes.length > 0) {
@@ -216,6 +233,9 @@ export async function createPartialDeploymentsComponent(
           return { complete: true, result: { message: `Your scene was deployed to World "${worldName}".` } }
         }
       }
+      // Finalize failed without deploying: release the lease so a later request can retry. A terminal
+      // validation error still propagates as a 4xx (the client won't retry; the row expires via TTL).
+      await pendingScenesManager.releaseFinalizationLease(entity.id).catch(() => undefined)
       throw error
     }
   }

--- a/src/logic/partial-deployments/index.ts
+++ b/src/logic/partial-deployments/index.ts
@@ -1,0 +1,1 @@
+export { createPartialDeploymentsComponent } from './component'

--- a/src/logic/partial-deployments/index.ts
+++ b/src/logic/partial-deployments/index.ts
@@ -1,1 +1,2 @@
 export { createPartialDeploymentsComponent } from './component'
+export * from './types'

--- a/src/logic/partial-deployments/types.ts
+++ b/src/logic/partial-deployments/types.ts
@@ -1,0 +1,32 @@
+import { AuthChain, Entity } from '@dcl/schemas'
+// Type-only import: DeploymentFile/DeploymentResult are shared types in the central types module, which
+// in turn references IPartialDeploymentsComponent for AppComponents — keeping this import type-only
+// erases the edge so there is no runtime import cycle.
+import type { DeploymentFile, DeploymentResult } from '../../types'
+
+export type StageDeploymentInput = {
+  baseUrl: string
+  entity: Entity
+  entityRaw: string
+  authChain: AuthChain
+  files: Map<string, DeploymentFile>
+}
+
+export type StageDeploymentResult = {
+  /** Whether this request completed the content set and the scene was deployed. */
+  complete: boolean
+  /** Content hashes still missing (present when `complete` is false). */
+  missing?: string[]
+  /** The deployment result (present when `complete` is true). */
+  result?: DeploymentResult
+}
+
+export type IPartialDeploymentsComponent = {
+  /**
+   * Stages one request of a partial scene deployment: validates everything that doesn't need the full
+   * content set, stores the uploaded files, records/refreshes the pending scene, and — when this
+   * request completes the content set — runs the full validation + deploy and returns the result.
+   * Throws `InvalidRequestError` (HTTP 400) on client errors.
+   */
+  stage(input: StageDeploymentInput): Promise<StageDeploymentResult>
+}

--- a/src/logic/validations/common.ts
+++ b/src/logic/validations/common.ts
@@ -114,6 +114,18 @@ export const validateNoMissingFiles: Validation = async (
   return createValidationResult(errors)
 }
 
+/**
+ * Full-deployment file validation: runs the uploaded-file checks and the no-missing-files check and
+ * returns their errors combined. Listing the two separately in `validateAll` would short-circuit on
+ * the first failure and hide the missing-file errors behind uploaded-file errors — the original
+ * `validateFiles` reported both together, which this preserves. Not used while staging a partial
+ * deployment (completeness is intentionally not required there).
+ */
+export const validateFiles: Validation = async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
+  const [uploaded, missing] = await Promise.all([validateUploadedFiles(deployment), validateNoMissingFiles(deployment)])
+  return createValidationResult([...uploaded.errors, ...missing.errors])
+}
+
 export const validateSupportedEntityType = async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
   switch (deployment.entity.type) {
     case EntityType.SCENE:

--- a/src/logic/validations/common.ts
+++ b/src/logic/validations/common.ts
@@ -28,7 +28,11 @@ export const validateBaseEntity: Validation = async (deployment: DeploymentToVal
 
 export function createValidateDeploymentTtl(components: Pick<ValidatorComponents, 'config'>) {
   return async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
-    const ttl = Date.now() - deployment.entity.timestamp
+    // A partial (multi-request) upload can span longer than the deployment TTL, so when a pending
+    // upload exists the entity's freshness is measured against when the upload started
+    // (pendingCreatedAt) rather than now. Full deploys have no pending row and anchor on Date.now().
+    const anchor = deployment.pendingCreatedAt?.getTime() ?? Date.now()
+    const ttl = anchor - deployment.entity.timestamp
     const maxTtl = (await components.config.getNumber('DEPLOYMENT_TTL')) || 300_000
     if (ttl > maxTtl) {
       return createValidationResult([
@@ -62,10 +66,16 @@ export const validateSignature: Validation = async (deployment: DeploymentToVali
   return createValidationResult(result.message ? [result.message] : [])
 }
 
-export const validateFiles: Validation = async (deployment: DeploymentToValidate): Promise<ValidationResult> => {
+/**
+ * Validates the files uploaded in *this* request: each must be referenced by the entity (or be the
+ * entity file), be a CIDv1, and hash to its declared key. Runs in both the full and staging validation
+ * paths — it does not depend on the full content set being present.
+ */
+export const validateUploadedFiles: Validation = async (
+  deployment: DeploymentToValidate
+): Promise<ValidationResult> => {
   const errors: string[] = []
 
-  // validate all files are part of the entity
   for (const [hash] of deployment.files) {
     // detect extra file
     if (!deployment.entity.content!.some(($) => $.hash === hash) && hash !== deployment.entity.id) {
@@ -81,7 +91,19 @@ export const validateFiles: Validation = async (deployment: DeploymentToValidate
     }
   }
 
-  // then ensure that all missing files are uploaded
+  return createValidationResult(errors)
+}
+
+/**
+ * Validates that every file the entity references is present — either uploaded now or already stored.
+ * Only meaningful once the full content set can be present, so it runs in the full validation path but
+ * NOT while staging a partial deployment.
+ */
+export const validateNoMissingFiles: Validation = async (
+  deployment: DeploymentToValidate
+): Promise<ValidationResult> => {
+  const errors: string[] = []
+
   for (const file of deployment.entity.content!) {
     const isFilePresent = deployment.files.has(file.hash) || deployment.contentHashesInStorage.get(file.hash)
     if (!isFilePresent) {

--- a/src/logic/validations/validator.ts
+++ b/src/logic/validations/validator.ts
@@ -83,14 +83,21 @@ export function createValidateFns(components: ValidatorComponents): Validation[]
  * `createValidateSize` (needs every file present; the partial-deployments component runs a cumulative
  * size check instead). Still runs the deployment-permission check so staging is fully authorized.
  */
-export function createStagingValidateFns(components: ValidatorComponents): Validation[] {
+export function createStagingValidateFns(
+  components: ValidatorComponents,
+  options?: { skipPermissionCheck?: boolean }
+): Validation[] {
+  const sceneValidations = sceneStructuralValidations(components)
+  // The permission check is the slow, external call of the staging path. Resume batches of an upload
+  // that already holds a pending record skip it (see Validator.validateStaging docs) so each batch of a
+  // multi-request upload doesn't repeat it; the first request and the finalize step always run it.
+  if (!options?.skipPermissionCheck) {
+    sceneValidations.push(createValidateDeploymentPermission(components))
+  }
   return [
     validateAll([...commonValidations(components), validateUploadedFiles, validateSupportedEntityType]),
 
-    validateIfTypeMatches(
-      EntityType.SCENE,
-      validateAll([...sceneStructuralValidations(components), createValidateDeploymentPermission(components)])
-    )
+    validateIfTypeMatches(EntityType.SCENE, validateAll(sceneValidations))
   ]
 }
 
@@ -108,7 +115,10 @@ export const createValidator = (components: ValidatorComponents): Validator => (
   async validate(deployment: DeploymentToValidate): Promise<ValidationResult> {
     return runValidations(createValidateFns(components), deployment)
   },
-  async validateStaging(deployment: DeploymentToValidate): Promise<ValidationResult> {
-    return runValidations(createStagingValidateFns(components), deployment)
+  async validateStaging(
+    deployment: DeploymentToValidate,
+    options?: { skipPermissionCheck?: boolean }
+  ): Promise<ValidationResult> {
+    return runValidations(createStagingValidateFns(components, options), deployment)
   }
 })

--- a/src/logic/validations/validator.ts
+++ b/src/logic/validations/validator.ts
@@ -4,10 +4,11 @@ import {
   validateAuthChain,
   validateBaseEntity,
   validateEntityId,
-  validateFiles,
+  validateNoMissingFiles,
   validateSignature,
   validateSigner,
-  validateSupportedEntityType
+  validateSupportedEntityType,
+  validateUploadedFiles
 } from './common'
 import {
   createValidateBannedNames,
@@ -26,35 +27,46 @@ import {
 import { OK, validateAll, validateIfTypeMatches } from './utils'
 import { EntityType } from '@dcl/schemas'
 
+// Common validations that don't depend on the full content set being present (run in both phases).
+function commonValidations(components: ValidatorComponents): Validation[] {
+  return [
+    validateEntityId,
+    validateBaseEntity,
+    validateAuthChain,
+    validateSigner,
+    validateSignature,
+    createValidateDeploymentTtl(components),
+    validateUploadedFiles
+  ]
+}
+
+// Scene structural validations that only inspect the entity / its declared content (run in both phases).
+function sceneStructuralValidations(components: ValidatorComponents): Validation[] {
+  return [
+    validateSceneEntity,
+    validateDeprecatedConfig,
+    createValidateParcelCoordinates(components),
+    createValidateScenePointers(components),
+    createValidateSceneDimensions(components),
+    createValidateFileCount(components),
+    validateMiniMapImages,
+    validateSkyboxTextures,
+    validateThumbnail,
+    createValidateBannedNames(components)
+    // validateSdkVersion(components) TODO re-enable (and test) once SDK7 is ready
+  ]
+}
+
 export function createValidateFns(components: ValidatorComponents): Validation[] {
   return [
     // Common validations to all entity types
-    validateAll([
-      validateEntityId,
-      validateBaseEntity,
-      validateAuthChain,
-      validateSigner,
-      validateSignature,
-      createValidateDeploymentTtl(components),
-      validateFiles,
-      validateSupportedEntityType
-    ]),
+    validateAll([...commonValidations(components), validateNoMissingFiles, validateSupportedEntityType]),
 
     // Scene entity validations
     validateIfTypeMatches(
       EntityType.SCENE,
       validateAll([
-        validateSceneEntity,
-        validateDeprecatedConfig,
-        createValidateParcelCoordinates(components),
-        createValidateScenePointers(components),
-        createValidateSceneDimensions(components),
-        createValidateFileCount(components),
-        validateMiniMapImages,
-        validateSkyboxTextures,
-        validateThumbnail,
-        createValidateBannedNames(components),
-        // validateSdkVersion(components) TODO re-enable (and test) once SDK7 is ready
+        ...sceneStructuralValidations(components),
         createValidateSize(components), // Slow
         createValidateDeploymentPermission(components) // Slow
       ])
@@ -64,16 +76,38 @@ export function createValidateFns(components: ValidatorComponents): Validation[]
   ]
 }
 
+/**
+ * The validations a partial (staging) scene deployment must pass on every request, before all of its
+ * content is necessarily present. Excludes `validateNoMissingFiles` (content completeness) and
+ * `createValidateSize` (needs every file present; the partial-deployments component runs a cumulative
+ * size check instead). Still runs the deployment-permission check so staging is fully authorized.
+ */
+export function createStagingValidateFns(components: ValidatorComponents): Validation[] {
+  return [
+    validateAll([...commonValidations(components), validateSupportedEntityType]),
+
+    validateIfTypeMatches(
+      EntityType.SCENE,
+      validateAll([...sceneStructuralValidations(components), createValidateDeploymentPermission(components)])
+    )
+  ]
+}
+
+async function runValidations(validations: Validation[], deployment: DeploymentToValidate): Promise<ValidationResult> {
+  for (const validation of validations) {
+    const result = await validation(deployment)
+    if (!result.ok()) {
+      return result
+    }
+  }
+  return OK
+}
+
 export const createValidator = (components: ValidatorComponents): Validator => ({
   async validate(deployment: DeploymentToValidate): Promise<ValidationResult> {
-    const validations = createValidateFns(components)
-    for (const validation of validations) {
-      const result = await validation(deployment)
-      if (!result.ok()) {
-        return result
-      }
-    }
-
-    return OK
+    return runValidations(createValidateFns(components), deployment)
+  },
+  async validateStaging(deployment: DeploymentToValidate): Promise<ValidationResult> {
+    return runValidations(createStagingValidateFns(components), deployment)
   }
 })

--- a/src/logic/validations/validator.ts
+++ b/src/logic/validations/validator.ts
@@ -4,7 +4,7 @@ import {
   validateAuthChain,
   validateBaseEntity,
   validateEntityId,
-  validateNoMissingFiles,
+  validateFiles,
   validateSignature,
   validateSigner,
   validateSupportedEntityType,
@@ -28,6 +28,8 @@ import { OK, validateAll, validateIfTypeMatches } from './utils'
 import { EntityType } from '@dcl/schemas'
 
 // Common validations that don't depend on the full content set being present (run in both phases).
+// File validation is added by each phase separately: the full path uses the combined `validateFiles`
+// (uploaded + no-missing, errors merged), while staging uses only `validateUploadedFiles`.
 function commonValidations(components: ValidatorComponents): Validation[] {
   return [
     validateEntityId,
@@ -35,8 +37,7 @@ function commonValidations(components: ValidatorComponents): Validation[] {
     validateAuthChain,
     validateSigner,
     validateSignature,
-    createValidateDeploymentTtl(components),
-    validateUploadedFiles
+    createValidateDeploymentTtl(components)
   ]
 }
 
@@ -60,7 +61,7 @@ function sceneStructuralValidations(components: ValidatorComponents): Validation
 export function createValidateFns(components: ValidatorComponents): Validation[] {
   return [
     // Common validations to all entity types
-    validateAll([...commonValidations(components), validateNoMissingFiles, validateSupportedEntityType]),
+    validateAll([...commonValidations(components), validateFiles, validateSupportedEntityType]),
 
     // Scene entity validations
     validateIfTypeMatches(
@@ -84,7 +85,7 @@ export function createValidateFns(components: ValidatorComponents): Validation[]
  */
 export function createStagingValidateFns(components: ValidatorComponents): Validation[] {
   return [
-    validateAll([...commonValidations(components), validateSupportedEntityType]),
+    validateAll([...commonValidations(components), validateUploadedFiles, validateSupportedEntityType]),
 
     validateIfTypeMatches(
       EntityType.SCENE,

--- a/src/migrations/0025_create_pending_scenes_table.ts
+++ b/src/migrations/0025_create_pending_scenes_table.ts
@@ -1,0 +1,24 @@
+import { Migration } from '../types'
+
+export const migration: Migration = {
+  id: '0025',
+  run: async ({ database }) => {
+    // Staging area for partial (multi-request) deployments. Intentionally NO foreign key to `worlds`:
+    // a half-uploaded world must not create a `worlds` row (which would leak into listings and world
+    // validity checks) before it goes live. The authoritative entity bytes live in content storage.
+    await database.query(`
+      CREATE TABLE pending_scenes (
+        entity_id  VARCHAR PRIMARY KEY,
+        world_name VARCHAR NOT NULL,
+        parcels    TEXT[]  NOT NULL,
+        entity     JSONB   NOT NULL,
+        deployer   VARCHAR NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+      CREATE INDEX pending_scenes_world_name_idx ON pending_scenes(world_name);
+      CREATE INDEX pending_scenes_parcels_idx ON pending_scenes USING GIN(parcels);
+      CREATE INDEX pending_scenes_created_at_idx ON pending_scenes(created_at);
+    `)
+  }
+}

--- a/src/migrations/0025_create_pending_scenes_table.ts
+++ b/src/migrations/0025_create_pending_scenes_table.ts
@@ -13,6 +13,11 @@ export const migration: Migration = {
         parcels    TEXT[]  NOT NULL,
         entity     JSONB   NOT NULL,
         deployer   VARCHAR NOT NULL,
+        -- Finalization lease: 'UPLOADING' while content is being staged; a completing request flips it
+        -- to 'FINALIZING' (recording finalizing_at) so only one request runs the expensive validation +
+        -- deploy. A stale lease (finalizing_at older than the lease TTL) can be taken over after a crash.
+        status     VARCHAR NOT NULL DEFAULT 'UPLOADING',
+        finalizing_at TIMESTAMPTZ NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );

--- a/src/migrations/0025_create_pending_scenes_table.ts
+++ b/src/migrations/0025_create_pending_scenes_table.ts
@@ -19,6 +19,8 @@ export const migration: Migration = {
       CREATE INDEX pending_scenes_world_name_idx ON pending_scenes(world_name);
       CREATE INDEX pending_scenes_parcels_idx ON pending_scenes USING GIN(parcels);
       CREATE INDEX pending_scenes_created_at_idx ON pending_scenes(created_at);
+      -- Backs the per-deployer concurrent-pending cap check (WHERE deployer = $ AND created_at >= $).
+      CREATE INDEX pending_scenes_deployer_created_at_idx ON pending_scenes(deployer, created_at);
     `)
   }
 }

--- a/src/migrations/all-migrations.ts
+++ b/src/migrations/all-migrations.ts
@@ -23,6 +23,7 @@ import { migration as migration_0021 } from './0021_migrate_permissions_to_world
 import { migration as migration_0022 } from './0022_normalize_permission_parcels'
 import { migration as migration_0023 } from './0023_add_scene_deployment_status'
 import { migration as migration_0024 } from './0024_denormalize_world_scene_stats'
+import { migration as migration_0025 } from './0025_create_pending_scenes_table'
 
 export const allMigrations: Migration[] = [
   migration_0001,
@@ -48,5 +49,6 @@ export const allMigrations: Migration[] = [
   migration_0021,
   migration_0022,
   migration_0023,
-  migration_0024
+  migration_0024,
+  migration_0025
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,8 +331,11 @@ export type IPendingScenesManager = {
   getByEntityId(entityId: string): Promise<PendingScene | undefined>
   /**
    * Records/refreshes a pending scene, replacing any non-expired pending scene of the same world whose
-   * parcels overlap (enforces "at most one pending upload per world+parcel"). On conflict of the same
-   * entity id it only bumps updated_at so created_at (the TTL anchor) stays stable across resumes.
+   * parcels overlap (enforces "at most one pending upload per world+parcel"), but only when the incoming
+   * scene is newer (deployment ordering) than the overlapping ones — a strictly-newer overlapping upload
+   * causes a rejection instead. On conflict of the same entity id it only bumps updated_at so created_at
+   * (the TTL anchor) stays stable across resumes.
+   * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress.
    */
   upsert(input: UpsertPendingScene): Promise<PendingScene>
   deleteByEntityId(entityId: string): Promise<void>
@@ -343,6 +346,8 @@ export type IPendingScenesManager = {
    * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
    */
   getActivePendingKeys(): Promise<Set<string>>
+  /** Counts a deployer's non-expired pending uploads. Used to cap concurrent staged uploads per deployer. */
+  countActiveByDeployer(deployer: string): Promise<number>
 }
 
 export type StageDeploymentInput = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -328,8 +328,13 @@ export type IPendingScenesManager = {
    */
   upsert(input: UpsertPendingScene): Promise<PendingScene>
   deleteByEntityId(entityId: string): Promise<void>
-  /** Deletes pending scenes older than `olderThanMs`. Returns the number removed. */
-  deleteExpired(olderThanMs: number): Promise<number>
+  /** Deletes pending scenes older than the configured PENDING_DEPLOYMENT_TTL. Returns the number removed. */
+  deleteExpired(): Promise<number>
+  /**
+   * Returns the storage keys referenced by every non-expired pending scene: each entity id, its
+   * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
+   */
+  getActivePendingKeys(): Promise<Set<string>>
 }
 
 export type StageDeploymentInput = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,6 +352,15 @@ export type IPendingScenesManager = {
    * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
    */
   getActivePendingKeys(): Promise<Set<string>>
+  /**
+   * Atomically claims the finalization lease for a pending upload (flips UPLOADING → FINALIZING, or
+   * takes over a stale FINALIZING lease). Returns true if this caller holds the lease and should run the
+   * finalization; false if another request is already finalizing. Ensures only one request runs the
+   * expensive validation + deploy for a completed upload.
+   */
+  acquireFinalizationLease(entityId: string): Promise<boolean>
+  /** Releases the finalization lease (FINALIZING → UPLOADING) when a finalize attempt fails without deploying. */
+  releaseFinalizationLease(entityId: string): Promise<void>
 }
 
 export type StageDeploymentInput = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -335,9 +335,17 @@ export type IPendingScenesManager = {
    * scene is newer (deployment ordering) than the overlapping ones — a strictly-newer overlapping upload
    * causes a rejection instead. On conflict of the same entity id it only bumps updated_at so created_at
    * (the TTL anchor) stays stable across resumes.
-   * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress.
+   *
+   * When `limit.isNewUpload` is set, the per-deployer concurrent-pending cap (`maxPendingPerDeployer`) is
+   * enforced inside the same transaction under a per-deployer lock, so concurrent new uploads can't race
+   * past it.
+   * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress,
+   *   or if a new upload would exceed the per-deployer cap.
    */
-  upsert(input: UpsertPendingScene): Promise<PendingScene>
+  upsert(
+    input: UpsertPendingScene,
+    limit: { maxPendingPerDeployer: number; isNewUpload: boolean }
+  ): Promise<PendingScene>
   deleteByEntityId(entityId: string): Promise<void>
   /** Deletes pending scenes older than the configured PENDING_DEPLOYMENT_TTL. Returns the number removed. */
   deleteExpired(): Promise<number>

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,16 +336,14 @@ export type IPendingScenesManager = {
    * causes a rejection instead. On conflict of the same entity id it only bumps updated_at so created_at
    * (the TTL anchor) stays stable across resumes.
    *
-   * When `limit.isNewUpload` is set, the per-deployer concurrent-pending cap (`maxPendingPerDeployer`) is
-   * enforced inside the same transaction under a per-deployer lock, so concurrent new uploads can't race
-   * past it.
+   * The per-deployer concurrent-pending cap (`limit.maxPendingPerDeployer`) is enforced inside the same
+   * transaction under a per-deployer lock, on the NET row-count change (so a resume or a newer scene that
+   * replaces one of the deployer's own overlapping rows is not counted as an increase), so concurrent
+   * uploads can't race past it.
    * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress,
-   *   or if a new upload would exceed the per-deployer cap.
+   *   or if the upsert would put the deployer over the per-deployer cap.
    */
-  upsert(
-    input: UpsertPendingScene,
-    limit: { maxPendingPerDeployer: number; isNewUpload: boolean }
-  ): Promise<PendingScene>
+  upsert(input: UpsertPendingScene, limit: { maxPendingPerDeployer: number }): Promise<PendingScene>
   deleteByEntityId(entityId: string): Promise<void>
   /** Deletes pending scenes older than the configured PENDING_DEPLOYMENT_TTL. Returns the number removed. */
   deleteExpired(): Promise<number>
@@ -354,8 +352,6 @@ export type IPendingScenesManager = {
    * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
    */
   getActivePendingKeys(): Promise<Set<string>>
-  /** Counts a deployer's non-expired pending uploads. Used to cap concurrent staged uploads per deployer. */
-  countActiveByDeployer(deployer: string): Promise<number>
 }
 
 export type StageDeploymentInput = {
@@ -494,6 +490,12 @@ export type IWorldsManager = {
   getDeployedWorldCount(): Promise<{ ens: number; dcl: number }>
   getMetadataForWorld(worldName: string): Promise<WorldMetadata | undefined>
   getEntityForWorlds(worldNames: string[]): Promise<Entity[]>
+  /**
+   * Whether a strictly-newer scene (deployment ordering) is already deployed on this scene's parcels.
+   * A non-authoritative fast-fail for the deploy path (reject before storing content); deployScene
+   * performs the authoritative, race-free check under a per-world lock.
+   */
+  hasNewerDeployedScene(worldName: string, scene: Entity): Promise<boolean>
   deployScene(worldName: string, scene: Entity, owner: EthAddress): Promise<void>
   undeployScene(worldName: string, parcels: string[]): Promise<void>
   storeAccess(worldName: string, access: AccessSetting): Promise<void>

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,10 @@ import { IPublisherComponent } from '@dcl/sns-component'
 import { ISettingsComponent } from './logic/settings'
 import { ISchemaValidatorComponent } from '@dcl/schema-validator-component'
 import { ICoordinatesComponent } from './logic/coordinates'
+// Type-only imports so the central types module can reference these component interfaces (for
+// AppComponents below) without a runtime import cycle through their component.ts factories.
+import type { IPendingScenesManager } from './adapters/pending-scenes-manager/types'
+import type { IPartialDeploymentsComponent } from './logic/partial-deployments/types'
 import { ISearchComponent } from './adapters/search'
 import {
   IPermissionsComponent,
@@ -302,93 +306,9 @@ export type MigratorComponents = Pick<
 
 export type Validation = (deployment: DeploymentToValidate) => ValidationResult | Promise<ValidationResult>
 
-/**
- * A partial (multi-request) deployment being staged. Content is uploaded across several requests and
- * the entity only becomes a live world_scenes row once every referenced file is present. Stored in a
- * standalone `pending_scenes` table (no FK to `worlds`, so a half-uploaded world never leaks into
- * listings). The authoritative entity *bytes* live in content storage under the entity id.
- */
-export type PendingScene = {
-  entityId: string
-  worldName: string
-  parcels: string[]
-  entity: Entity
-  deployer: string
-  createdAt: Date
-  updatedAt: Date
-}
-
-export type UpsertPendingScene = {
-  entityId: string
-  worldName: string
-  parcels: string[]
-  entity: Entity
-  deployer: string
-}
-
-export type IPendingScenesManager = {
-  /** Returns the pending scene for an entity id, treating rows past the TTL as absent. */
-  getByEntityId(entityId: string): Promise<PendingScene | undefined>
-  /**
-   * Records/refreshes a pending scene, replacing any non-expired pending scene of the same world whose
-   * parcels overlap (enforces "at most one pending upload per world+parcel"), but only when the incoming
-   * scene is newer (deployment ordering) than the overlapping ones — a strictly-newer overlapping upload
-   * causes a rejection instead. On conflict of the same entity id it only bumps updated_at so created_at
-   * (the TTL anchor) stays stable across resumes.
-   *
-   * The per-deployer concurrent-pending cap (`limit.maxPendingPerDeployer`) is enforced inside the same
-   * transaction under a per-deployer lock, on the NET row-count change (so a resume or a newer scene that
-   * replaces one of the deployer's own overlapping rows is not counted as an increase), so concurrent
-   * uploads can't race past it.
-   * @throws InvalidRequestError if a strictly-newer overlapping pending upload is already in progress,
-   *   or if the upsert would put the deployer over the per-deployer cap.
-   */
-  upsert(input: UpsertPendingScene, limit: { maxPendingPerDeployer: number }): Promise<PendingScene>
-  deleteByEntityId(entityId: string): Promise<void>
-  /** Deletes pending scenes older than the configured PENDING_DEPLOYMENT_TTL. Returns the number removed. */
-  deleteExpired(): Promise<number>
-  /**
-   * Returns the storage keys referenced by every non-expired pending scene: each entity id, its
-   * `.auth` blob, and its content-file hashes. Used by garbage collection to protect in-flight uploads.
-   */
-  getActivePendingKeys(): Promise<Set<string>>
-  /**
-   * Atomically claims the finalization lease for a pending upload (flips UPLOADING → FINALIZING, or
-   * takes over a stale FINALIZING lease). Returns true if this caller holds the lease and should run the
-   * finalization; false if another request is already finalizing. Ensures only one request runs the
-   * expensive validation + deploy for a completed upload.
-   */
-  acquireFinalizationLease(entityId: string): Promise<boolean>
-  /** Releases the finalization lease (FINALIZING → UPLOADING) when a finalize attempt fails without deploying. */
-  releaseFinalizationLease(entityId: string): Promise<void>
-}
-
-export type StageDeploymentInput = {
-  baseUrl: string
-  entity: Entity
-  entityRaw: string
-  authChain: AuthChain
-  files: Map<string, DeploymentFile>
-}
-
-export type StageDeploymentResult = {
-  /** Whether this request completed the content set and the scene was deployed. */
-  complete: boolean
-  /** Content hashes still missing (present when `complete` is false). */
-  missing?: string[]
-  /** The deployment result (present when `complete` is true). */
-  result?: DeploymentResult
-}
-
-export type IPartialDeploymentsComponent = {
-  /**
-   * Stages one request of a partial scene deployment: validates everything that doesn't need the full
-   * content set, stores the uploaded files, records/refreshes the pending scene, and — when this
-   * request completes the content set — runs the full validation + deploy and returns the result.
-   * Throws `InvalidRequestError` (HTTP 400) on client errors.
-   */
-  stage(input: StageDeploymentInput): Promise<StageDeploymentResult>
-}
+// PendingScene / UpsertPendingScene / IPendingScenesManager live in ./adapters/pending-scenes-manager/types
+// StageDeploymentInput / StageDeploymentResult / IPartialDeploymentsComponent live in
+// ./logic/partial-deployments/types (both imported above for AppComponents).
 
 export type INameOwnership = {
   findOwners(worldNames: string[]): Promise<ReadonlyMap<string, EthAddress | undefined>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,12 @@ export type DeploymentToValidate = {
   files: Map<string, DeploymentFile>
   authChain: AuthChain
   contentHashesInStorage: Map<string, boolean>
+  /**
+   * created_at of the pending (partial) upload for this entity, when one exists. The deployment TTL
+   * check validates the entity timestamp against this anchor instead of now, so a multi-request upload
+   * can span longer than the TTL.
+   */
+  pendingCreatedAt?: Date
 }
 
 export type WorldRuntimeMetadata = {
@@ -257,6 +263,11 @@ export type AccessControlList = {
 
 export interface Validator {
   validate(deployment: DeploymentToValidate): Promise<ValidationResult>
+  /**
+   * Validations a partial (staging) scene deployment must pass before its full content set is present:
+   * everything except content-completeness and the storage-backed size check.
+   */
+  validateStaging(deployment: DeploymentToValidate): Promise<ValidationResult>
 }
 
 export type ValidationResult = {
@@ -282,6 +293,71 @@ export type MigratorComponents = Pick<
 >
 
 export type Validation = (deployment: DeploymentToValidate) => ValidationResult | Promise<ValidationResult>
+
+/**
+ * A partial (multi-request) deployment being staged. Content is uploaded across several requests and
+ * the entity only becomes a live world_scenes row once every referenced file is present. Stored in a
+ * standalone `pending_scenes` table (no FK to `worlds`, so a half-uploaded world never leaks into
+ * listings). The authoritative entity *bytes* live in content storage under the entity id.
+ */
+export type PendingScene = {
+  entityId: string
+  worldName: string
+  parcels: string[]
+  entity: Entity
+  deployer: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type UpsertPendingScene = {
+  entityId: string
+  worldName: string
+  parcels: string[]
+  entity: Entity
+  deployer: string
+}
+
+export type IPendingScenesManager = {
+  /** Returns the pending scene for an entity id, treating rows past the TTL as absent. */
+  getByEntityId(entityId: string): Promise<PendingScene | undefined>
+  /**
+   * Records/refreshes a pending scene, replacing any non-expired pending scene of the same world whose
+   * parcels overlap (enforces "at most one pending upload per world+parcel"). On conflict of the same
+   * entity id it only bumps updated_at so created_at (the TTL anchor) stays stable across resumes.
+   */
+  upsert(input: UpsertPendingScene): Promise<PendingScene>
+  deleteByEntityId(entityId: string): Promise<void>
+  /** Deletes pending scenes older than `olderThanMs`. Returns the number removed. */
+  deleteExpired(olderThanMs: number): Promise<number>
+}
+
+export type StageDeploymentInput = {
+  baseUrl: string
+  entity: Entity
+  entityRaw: string
+  authChain: AuthChain
+  files: Map<string, DeploymentFile>
+}
+
+export type StageDeploymentResult = {
+  /** Whether this request completed the content set and the scene was deployed. */
+  complete: boolean
+  /** Content hashes still missing (present when `complete` is false). */
+  missing?: string[]
+  /** The deployment result (present when `complete` is true). */
+  result?: DeploymentResult
+}
+
+export type IPartialDeploymentsComponent = {
+  /**
+   * Stages one request of a partial scene deployment: validates everything that doesn't need the full
+   * content set, stores the uploaded files, records/refreshes the pending scene, and — when this
+   * request completes the content set — runs the full validation + deploy and returns the result.
+   * Throws `InvalidRequestError` (HTTP 400) on client errors.
+   */
+  stage(input: StageDeploymentInput): Promise<StageDeploymentResult>
+}
 
 export type INameOwnership = {
   findOwners(worldNames: string[]): Promise<ReadonlyMap<string, EthAddress | undefined>>
@@ -548,6 +624,8 @@ export type BaseComponents = {
   marketplaceSubGraph: ISubgraphComponent
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
   migrationExecutor: MigrationExecutor
+  partialDeployments: IPartialDeploymentsComponent
+  pendingScenesManager: IPendingScenesManager
   nats: INatsComponent
   nameDenyListChecker: INameDenyListChecker
   nameOwnership: INameOwnership

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,8 +266,16 @@ export interface Validator {
   /**
    * Validations a partial (staging) scene deployment must pass before its full content set is present:
    * everything except content-completeness and the storage-backed size check.
+   *
+   * `skipPermissionCheck` skips the (slow, external) deployment-permission check. Safe only when the
+   * upload already has a non-expired pending record: creating that record required passing the
+   * permission check, uploaded bytes are hash-verified against the staged manifest, and the finalize
+   * step re-runs the full validation (including permission) before anything goes live.
    */
-  validateStaging(deployment: DeploymentToValidate): Promise<ValidationResult>
+  validateStaging(
+    deployment: DeploymentToValidate,
+    options?: { skipPermissionCheck?: boolean }
+  ): Promise<ValidationResult>
 }
 
 export type ValidationResult = {

--- a/test/components.ts
+++ b/test/components.ts
@@ -16,6 +16,8 @@ import { createWorldsIndexerComponent } from '../src/adapters/worlds-indexer'
 import { IFetchComponent } from '@dcl/core-commons'
 
 import { createValidator } from '../src/logic/validations'
+import { createPendingScenesManager } from '../src/adapters/pending-scenes-manager'
+import { createPartialDeploymentsComponent } from '../src/logic/partial-deployments'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { metricDeclarations } from '../src/metrics'
 import { createEntityDeployer } from '../src/adapters/entity-deployer'
@@ -208,6 +210,20 @@ async function initComponents(): Promise<TestComponents> {
     storage,
     worldsManager
   })
+
+  const pendingScenesManager = await createPendingScenesManager({ config, database, logs })
+
+  const partialDeployments = createPartialDeploymentsComponent({
+    coordinates,
+    entityDeployer,
+    limitsManager,
+    logs,
+    pendingScenesManager,
+    storage,
+    validator,
+    worldsManager
+  })
+
   const status = createMockStatusComponent()
 
   const updateOwnerJob = await createMockUpdateOwnerJob({})
@@ -268,6 +284,8 @@ async function initComponents(): Promise<TestComponents> {
     nats: createMockNatsComponent(),
     permissionsManager,
     peersRegistry,
+    partialDeployments,
+    pendingScenesManager,
     queueConsumer,
     rateLimiter,
     redis,

--- a/test/components.ts
+++ b/test/components.ts
@@ -213,7 +213,8 @@ async function initComponents(): Promise<TestComponents> {
 
   const pendingScenesManager = await createPendingScenesManager({ config, database, logs })
 
-  const partialDeployments = createPartialDeploymentsComponent({
+  const partialDeployments = await createPartialDeploymentsComponent({
+    config,
     coordinates,
     entityDeployer,
     limitsManager,

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -727,4 +727,46 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       expect(await countPending()).toBe(3)
     })
   })
+
+  describe('when a completing request arrives while finalization is already in progress', () => {
+    let completingResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hash1, hash2] = contentHashes
+      // Stage the entity + first content file (incomplete → pending row, status UPLOADING).
+      await post(buildForm([entityId, hash1], authChain))
+      // Simulate another request holding a FRESH finalization lease on this upload.
+      await components.database.query(
+        `UPDATE pending_scenes SET status = 'FINALIZING', finalizing_at = now() WHERE entity_id = '${entityId}'`
+      )
+      // The completing request uploads the last file but can't claim the lease.
+      completingResponse = await post(buildForm([hash2], authChain))
+    })
+
+    it('should respond 202 (finalization in progress) without deploying the scene', async () => {
+      expect(completingResponse.status).toBe(202)
+      expect(await countDeployedScenes()).toBe(0)
+    })
+  })
+
+  describe('when a completing request finds a stale (crashed) finalization lease', () => {
+    let completingResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hash1, hash2] = contentHashes
+      await post(buildForm([entityId, hash1], authChain))
+      // A crashed finalizer left a lease older than the 2-minute TTL.
+      await components.database.query(
+        `UPDATE pending_scenes SET status = 'FINALIZING', finalizing_at = now() - interval '10 minutes' WHERE entity_id = '${entityId}'`
+      )
+      completingResponse = await post(buildForm([hash2], authChain))
+    })
+
+    it('should take over the stale lease and finalize with 200', async () => {
+      expect(completingResponse.status).toBe(200)
+      expect(await countDeployedScenes()).toBe(1)
+    })
+  })
 })

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -164,6 +164,24 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       expect(namePermissionChecker.checkPermission).toHaveBeenCalledTimes(2)
     })
 
+    it('should reject the completing request when the deployer loses the name permission mid-upload', async () => {
+      const { namePermissionChecker } = stubComponents
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hashA, hashB] = contentHashes
+
+      expect((await post(buildForm([entityId, hashA], authChain))).status).toBe(202)
+
+      // The name is traded away mid-upload: the permission checker resolves the CURRENT owner, which is
+      // no longer the deployer. The resume batch itself is accepted for staging (same-deployer fast
+      // path), but the finalize step re-runs the full validation and must reject the deploy.
+      namePermissionChecker.checkPermission.mockResolvedValue(false)
+
+      const res = await post(buildForm([hashB], authChain))
+
+      expect(res.status).toBe(400)
+      expect(await countDeployedScenes()).toBe(0)
+    })
+
     it('should not grant the fast path to a different signer resuming the same entity', async () => {
       const authChain = Authenticator.signPayload(identity.authChain, entityId)
       expect((await post(buildForm([entityId], authChain))).status).toBe(202)

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -432,10 +432,18 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
   })
 
   // Generic form builder for a second entity (the module-level buildForm is bound to the beforeEach one).
-  function makeForm(id: string, fileMap: Map<string, Uint8Array>, keys: string[], authChain: AuthChain): FormData {
+  function makeForm(
+    id: string,
+    fileMap: Map<string, Uint8Array>,
+    keys: string[],
+    authChain: AuthChain,
+    partial = true
+  ): FormData {
     const form = new FormData()
     form.append('entityId', id)
-    form.append('partial', 'true')
+    if (partial) {
+      form.append('partial', 'true')
+    }
     authChain.forEach((link, i) => {
       form.append(`authChain[${i}][type]`, link.type)
       form.append(`authChain[${i}][payload]`, link.payload)
@@ -627,6 +635,36 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
         const result = await database.query<{ entity_id: string }>('SELECT entity_id FROM pending_scenes')
         expect(result.rows.map((r) => r.entity_id)).toEqual([newer.entityId])
       })
+    })
+  })
+
+  describe('when a vanilla deploy targets parcels already held by a newer scene', () => {
+    let older: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let newer: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let olderResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
+      const now = Date.now()
+      older = await buildScene(['20,24'], now - 60_000)
+      newer = await buildScene(['20,24'], now)
+
+      // Deploy the newer scene first (full, single-request vanilla deploy).
+      const newerAuth = Authenticator.signPayload(identity.authChain, newer.entityId)
+      await post(makeForm(newer.entityId, newer.files, [newer.entityId, ...newer.contentHashes], newerAuth, false))
+
+      // Then a vanilla deploy of the older scene on the same parcels.
+      const olderAuth = Authenticator.signPayload(identity.authChain, older.entityId)
+      olderResponse = await post(
+        makeForm(older.entityId, older.files, [older.entityId, ...older.contentHashes], olderAuth, false)
+      )
+    })
+
+    it('should reject the older vanilla deploy with 400 (deployScene enforces ordering atomically)', () => {
+      expect(olderResponse.status).toBe(400)
+    })
+
+    it('should keep the newer scene deployed', async () => {
+      expect(await deployedEntityIds()).toEqual([newer.entityId])
     })
   })
 

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -100,154 +100,329 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
   })
 
   describe('when uploading a scene across multiple partial requests', () => {
-    it('should return 202 until the last request finalizes with 200 and makes the world live', async () => {
-      const { worldsManager } = components
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const [hash1, hash2] = contentHashes
+    let authChain: AuthChain
 
-      const res1 = await post(buildForm([entityId], authChain))
-      expect(res1.status).toBe(202)
-      expect(new Set((await res1.json()).missing)).toEqual(new Set([hash1, hash2]))
-      expect(await countPending()).toBe(1)
-      // The world is not live yet.
-      expect(await worldsManager.getMetadataForWorld(worldName)).toBeUndefined()
-
-      const res2 = await post(buildForm([hash1], authChain))
-      expect(res2.status).toBe(202)
-      expect((await res2.json()).missing).toEqual([hash2])
-
-      const res3 = await post(buildForm([hash2], authChain))
-      expect(res3.status).toBe(200)
-      expect((await res3.json()).message).toContain(`Your scene was deployed to World "${worldName}"`)
-
-      expect(await countPending()).toBe(0)
-      expect(await worldsManager.getMetadataForWorld(worldName)).toBeDefined()
+    beforeEach(() => {
+      authChain = Authenticator.signPayload(identity.authChain, entityId)
     })
 
-    it('should not require the entity file on requests after the first', async () => {
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+    describe('and each content file is uploaded in its own batch', () => {
+      let hash1: string
+      let hash2: string
+      let firstResponse: Awaited<ReturnType<typeof post>>
 
-      const res1 = await post(buildForm([entityId, contentHashes[0]], authChain))
-      expect(res1.status).toBe(202)
+      beforeEach(async () => {
+        ;[hash1, hash2] = contentHashes
+        firstResponse = await post(buildForm([entityId], authChain))
+      })
 
-      // Second request omits the entity file; the server reads it back from storage.
-      const res2 = await post(buildForm([contentHashes[1]], authChain))
-      expect(res2.status).toBe(200)
-      expect(await countPending()).toBe(0)
+      it('should respond 202 with both content hashes missing', async () => {
+        expect(firstResponse.status).toBe(202)
+        expect(new Set((await firstResponse.json()).missing)).toEqual(new Set([hash1, hash2]))
+      })
+
+      it('should create a pending row without making the world live yet', async () => {
+        expect(await countPending()).toBe(1)
+        expect(await components.worldsManager.getMetadataForWorld(worldName)).toBeUndefined()
+      })
+
+      describe('and the second batch uploads the first content file', () => {
+        let secondResponse: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          secondResponse = await post(buildForm([hash1], authChain))
+        })
+
+        it('should respond 202 with only the remaining hash missing', async () => {
+          expect(secondResponse.status).toBe(202)
+          expect((await secondResponse.json()).missing).toEqual([hash2])
+        })
+
+        describe('and the last batch uploads the remaining content file', () => {
+          let thirdResponse: Awaited<ReturnType<typeof post>>
+
+          beforeEach(async () => {
+            thirdResponse = await post(buildForm([hash2], authChain))
+          })
+
+          it('should finalize with 200 and the deployment message', async () => {
+            expect(thirdResponse.status).toBe(200)
+            expect((await thirdResponse.json()).message).toContain(`Your scene was deployed to World "${worldName}"`)
+          })
+
+          it('should delete the pending row and make the world live', async () => {
+            expect(await countPending()).toBe(0)
+            expect(await components.worldsManager.getMetadataForWorld(worldName)).toBeDefined()
+          })
+        })
+      })
+    })
+
+    describe('and requests after the first omit the entity file', () => {
+      let firstResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        firstResponse = await post(buildForm([entityId, contentHashes[0]], authChain))
+      })
+
+      it('should accept the first batch with 202', () => {
+        expect(firstResponse.status).toBe(202)
+      })
+
+      describe('and the remaining content file is uploaded without the entity file', () => {
+        let secondResponse: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          // The request omits the entity file; the server reads it back from storage.
+          secondResponse = await post(buildForm([contentHashes[1]], authChain))
+        })
+
+        it('should finalize with 200 and no pending row', async () => {
+          expect(secondResponse.status).toBe(200)
+          expect(await countPending()).toBe(0)
+        })
+      })
     })
   })
 
   describe('when a single partial request contains all content', () => {
-    it('should finalize immediately and return 200', async () => {
-      const { worldsManager } = components
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+    let response: Awaited<ReturnType<typeof post>>
 
-      const res = await post(buildForm([entityId, ...contentHashes], authChain))
-      expect(res.status).toBe(200)
+    beforeEach(async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      response = await post(buildForm([entityId, ...contentHashes], authChain))
+    })
+
+    it('should finalize immediately and return 200', async () => {
+      expect(response.status).toBe(200)
       expect(await countPending()).toBe(0)
-      expect(await worldsManager.getMetadataForWorld(worldName)).toBeDefined()
+      expect(await components.worldsManager.getMetadataForWorld(worldName)).toBeDefined()
     })
   })
 
   describe('when uploading across multiple requests (resume fast-path)', () => {
-    it('should run the deployment-permission check only on the first request and at finalize, not per batch', async () => {
-      const { namePermissionChecker } = stubComponents
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const [hashA, hashB] = contentHashes
+    let authChain: AuthChain
+    let hashA: string
+    let hashB: string
 
-      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
-      expect((await post(buildForm([hashA], authChain))).status).toBe(202)
-      expect((await post(buildForm([hashB], authChain))).status).toBe(200)
-
-      // Request 1 (creates the pending record) runs the permission check; requests 2 and 3 are resume
-      // batches by the same deployer that skip it; finalize (inside request 3) re-runs it.
-      expect(namePermissionChecker.checkPermission).toHaveBeenCalledTimes(2)
+    beforeEach(() => {
+      authChain = Authenticator.signPayload(identity.authChain, entityId)
+      ;[hashA, hashB] = contentHashes
     })
 
-    it('should reject the completing request when the deployer loses the name permission mid-upload', async () => {
-      const { namePermissionChecker } = stubComponents
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const [hashA, hashB] = contentHashes
+    describe('and the same deployer uploads every batch', () => {
+      let firstResponse: Awaited<ReturnType<typeof post>>
 
-      expect((await post(buildForm([entityId, hashA], authChain))).status).toBe(202)
+      beforeEach(async () => {
+        firstResponse = await post(buildForm([entityId], authChain))
+      })
 
-      // The name is traded away mid-upload: the permission checker resolves the CURRENT owner, which is
-      // no longer the deployer. The resume batch itself is accepted for staging (same-deployer fast
-      // path), but the finalize step re-runs the full validation and must reject the deploy.
-      namePermissionChecker.checkPermission.mockResolvedValue(false)
+      it('should accept the request that creates the pending record with 202', () => {
+        expect(firstResponse.status).toBe(202)
+      })
 
-      const res = await post(buildForm([hashB], authChain))
+      describe('and the first content batch is uploaded', () => {
+        let secondResponse: Awaited<ReturnType<typeof post>>
 
-      expect(res.status).toBe(400)
-      expect(await countDeployedScenes()).toBe(0)
+        beforeEach(async () => {
+          secondResponse = await post(buildForm([hashA], authChain))
+        })
+
+        it('should accept the resume batch with 202', () => {
+          expect(secondResponse.status).toBe(202)
+        })
+
+        describe('and the last content batch is uploaded', () => {
+          let thirdResponse: Awaited<ReturnType<typeof post>>
+
+          beforeEach(async () => {
+            thirdResponse = await post(buildForm([hashB], authChain))
+          })
+
+          it('should finalize the upload with 200', () => {
+            expect(thirdResponse.status).toBe(200)
+          })
+
+          it('should run the deployment-permission check only on the first request and at finalize, not per batch', () => {
+            // Request 1 (creates the pending record) runs the permission check; requests 2 and 3 are resume
+            // batches by the same deployer that skip it; finalize (inside request 3) re-runs it.
+            expect(stubComponents.namePermissionChecker.checkPermission).toHaveBeenCalledTimes(2)
+          })
+        })
+      })
     })
 
-    it('should not grant the fast path to a different signer resuming the same entity', async () => {
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
+    describe('and the deployer loses the name permission mid-upload', () => {
+      let stagingResponse: Awaited<ReturnType<typeof post>>
 
-      // Another wallet (no deployment permission for this world) signs the same entity id and tries to
-      // continue the upload: it must go through the full staging validation and be rejected.
-      const otherIdentity = await getIdentity()
-      const otherAuthChain = Authenticator.signPayload(otherIdentity.authChain, entityId)
-      const res = await post(buildForm([contentHashes[0]], otherAuthChain))
+      beforeEach(async () => {
+        stagingResponse = await post(buildForm([entityId, hashA], authChain))
+      })
 
-      expect(res.status).toBe(400)
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
+
+      describe('and the name is traded away before the completing request', () => {
+        let completingResponse: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          // The name is traded away mid-upload: the permission checker resolves the CURRENT owner, which is
+          // no longer the deployer. The resume batch itself is accepted for staging (same-deployer fast
+          // path), but the finalize step re-runs the full validation and must reject the deploy.
+          stubComponents.namePermissionChecker.checkPermission.mockResolvedValue(false)
+
+          completingResponse = await post(buildForm([hashB], authChain))
+        })
+
+        it('should reject the completing request and not deploy the scene', async () => {
+          expect(completingResponse.status).toBe(400)
+          expect(await countDeployedScenes()).toBe(0)
+        })
+      })
+    })
+
+    describe('and a different signer resumes the same entity', () => {
+      let stagingResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        stagingResponse = await post(buildForm([entityId], authChain))
+      })
+
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
+
+      describe('and another wallet signs the same entity id and continues the upload', () => {
+        let resumeResponse: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          // Another wallet (no deployment permission for this world) signs the same entity id and tries to
+          // continue the upload: it must go through the full staging validation and be rejected.
+          const otherIdentity = await getIdentity()
+          const otherAuthChain = Authenticator.signPayload(otherIdentity.authChain, entityId)
+          resumeResponse = await post(buildForm([contentHashes[0]], otherAuthChain))
+        })
+
+        it('should reject the resume request with 400', () => {
+          expect(resumeResponse.status).toBe(400)
+        })
+      })
     })
   })
 
   describe('when the same partial request is replayed', () => {
-    it('should respond idempotently and keep a single pending row', async () => {
+    let firstResponse: Awaited<ReturnType<typeof post>>
+    let secondResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
       const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      firstResponse = await post(buildForm([entityId], authChain))
+      secondResponse = await post(buildForm([entityId], authChain))
+    })
 
-      const res1 = await post(buildForm([entityId], authChain))
-      const res2 = await post(buildForm([entityId], authChain))
+    it('should respond 202 to both requests with the same missing hashes', async () => {
+      expect(firstResponse.status).toBe(202)
+      expect(secondResponse.status).toBe(202)
+      expect(new Set((await secondResponse.json()).missing)).toEqual(new Set(contentHashes))
+    })
 
-      expect(res1.status).toBe(202)
-      expect(res2.status).toBe(202)
-      expect(new Set((await res2.json()).missing)).toEqual(new Set(contentHashes))
+    it('should keep a single pending row', async () => {
       expect(await countPending()).toBe(1)
     })
   })
 
   describe('when the first partial request omits the entity file', () => {
-    it('should return 400', async () => {
+    let response: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
       const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const res = await post(buildForm([contentHashes[0]], authChain))
-      expect(res.status).toBe(400)
+      response = await post(buildForm([contentHashes[0]], authChain))
+    })
+
+    it('should return 400 and not create a pending row', async () => {
+      expect(response.status).toBe(400)
       expect(await countPending()).toBe(0)
     })
   })
 
   describe('when staging requests for the same entity run in parallel', () => {
-    it('should accept two distinct content batches uploaded concurrently and deploy the world once', async () => {
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const [hashA, hashB] = contentHashes
+    let authChain: AuthChain
+    let hashA: string
+    let hashB: string
 
-      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
-
-      const [resA, resB] = await Promise.all([post(buildForm([hashA], authChain)), post(buildForm([hashB], authChain))])
-
-      const statuses = [resA.status, resB.status].sort()
-      expect(statuses.every((status) => status === 200 || status === 202)).toBe(true)
-      expect(statuses).toContain(200)
-      expect(await countDeployedScenes()).toBe(1)
-      expect(await countPending()).toBe(0)
+    beforeEach(() => {
+      authChain = Authenticator.signPayload(identity.authChain, entityId)
+      ;[hashA, hashB] = contentHashes
     })
 
-    it('should deploy once when two requests complete the content set at the same time', async () => {
-      const authChain = Authenticator.signPayload(identity.authChain, entityId)
-      const [hashA, hashB] = contentHashes
+    describe('and two distinct content batches are uploaded concurrently', () => {
+      let stagingResponse: Awaited<ReturnType<typeof post>>
 
-      // Stage entity + A, leaving only B missing.
-      expect((await post(buildForm([entityId, hashA], authChain))).status).toBe(202)
+      beforeEach(async () => {
+        stagingResponse = await post(buildForm([entityId], authChain))
+      })
 
-      // Two identical completing requests (both upload B) race to finalize.
-      const [res1, res2] = await Promise.all([post(buildForm([hashB], authChain)), post(buildForm([hashB], authChain))])
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
 
-      expect([res1.status, res2.status].sort()).toEqual([200, 200])
-      expect(await countDeployedScenes()).toBe(1)
-      expect(await countPending()).toBe(0)
+      describe('and the two remaining batches are sent at the same time', () => {
+        let responseA: Awaited<ReturnType<typeof post>>
+        let responseB: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          ;[responseA, responseB] = await Promise.all([
+            post(buildForm([hashA], authChain)),
+            post(buildForm([hashB], authChain))
+          ])
+        })
+
+        it('should respond to each batch with 200 or 202 and finalize exactly one', () => {
+          expect([responseA.status, responseB.status].every((status) => status === 200 || status === 202)).toBe(true)
+          expect([responseA.status, responseB.status]).toContain(200)
+        })
+
+        it('should deploy the world exactly once with no leftover pending row', async () => {
+          expect(await countDeployedScenes()).toBe(1)
+          expect(await countPending()).toBe(0)
+        })
+      })
+    })
+
+    describe('and two identical completing requests race to finalize', () => {
+      let stagingResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        // Stage entity + A, leaving only B missing.
+        stagingResponse = await post(buildForm([entityId, hashA], authChain))
+      })
+
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
+
+      describe('and both completing requests are sent at the same time', () => {
+        let firstResponse: Awaited<ReturnType<typeof post>>
+        let secondResponse: Awaited<ReturnType<typeof post>>
+
+        beforeEach(async () => {
+          // Two identical completing requests (both upload B) race to finalize.
+          ;[firstResponse, secondResponse] = await Promise.all([
+            post(buildForm([hashB], authChain)),
+            post(buildForm([hashB], authChain))
+          ])
+        })
+
+        it('should return 200 to both requests', () => {
+          expect([firstResponse.status, secondResponse.status].sort()).toEqual([200, 200])
+        })
+
+        it('should deploy the world exactly once with no leftover pending row', async () => {
+          expect(await countDeployedScenes()).toBe(1)
+          expect(await countPending()).toBe(0)
+        })
+      })
     })
   })
 
@@ -301,7 +476,8 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
   describe('when a stale pending upload would finalize over a newer deployment', () => {
     let older: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
     let newer: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
-    let completeResponse: Response
+    let olderAuth: AuthChain
+    let stageOlderResponse: Awaited<ReturnType<typeof post>>
 
     beforeEach(async () => {
       const now = Date.now()
@@ -309,42 +485,57 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       newer = await buildScene(['20,24'], now)
 
       // Stage the older scene partially (entity only) — no newer scene exists yet, so this is accepted.
-      const olderAuth = Authenticator.signPayload(identity.authChain, older.entityId)
-      const stageOlder = await post(makeForm(older.entityId, older.files, [older.entityId], olderAuth))
-      expect(stageOlder.status).toBe(202)
+      olderAuth = Authenticator.signPayload(identity.authChain, older.entityId)
+      stageOlderResponse = await post(makeForm(older.entityId, older.files, [older.entityId], olderAuth))
+    })
 
-      // A newer scene is then deployed on the same parcels via a normal single-request deploy.
-      const newerAuth = Authenticator.signPayload(identity.authChain, newer.entityId)
-      const newerForm = new FormData()
-      newerForm.append('entityId', newer.entityId)
-      newerAuth.forEach((link, i) => {
-        newerForm.append(`authChain[${i}][type]`, link.type)
-        newerForm.append(`authChain[${i}][payload]`, link.payload)
-        newerForm.append(`authChain[${i}][signature]`, link.signature ?? '')
+    it('should accept staging the older scene with 202', () => {
+      expect(stageOlderResponse.status).toBe(202)
+    })
+
+    describe('and a newer scene is then deployed on the same parcels', () => {
+      let newerDeployResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        // The newer scene is deployed on the same parcels via a normal single-request deploy.
+        const newerAuth = Authenticator.signPayload(identity.authChain, newer.entityId)
+        const newerForm = new FormData()
+        newerForm.append('entityId', newer.entityId)
+        newerAuth.forEach((link, i) => {
+          newerForm.append(`authChain[${i}][type]`, link.type)
+          newerForm.append(`authChain[${i}][payload]`, link.payload)
+          newerForm.append(`authChain[${i}][signature]`, link.signature ?? '')
+        })
+        for (const key of [newer.entityId, ...newer.contentHashes]) {
+          newerForm.append(key, Buffer.from(newer.files.get(key)!), { filename: key })
+        }
+        newerDeployResponse = await post(newerForm)
       })
-      for (const key of [newer.entityId, ...newer.contentHashes]) {
-        newerForm.append(key, Buffer.from(newer.files.get(key)!), { filename: key })
-      }
-      expect((await post(newerForm)).status).toBe(200)
 
-      // Now the stalled client completes the older upload.
-      completeResponse = (await post(
-        makeForm(older.entityId, older.files, older.contentHashes, olderAuth)
-      )) as unknown as Response
-    })
+      it('should deploy the newer scene with 200', () => {
+        expect(newerDeployResponse.status).toBe(200)
+      })
 
-    it('should reject the stale finalize', () => {
-      expect(completeResponse.status).toBe(400)
-    })
+      describe('and the stalled client completes the older upload', () => {
+        let completeResponse: Awaited<ReturnType<typeof post>>
 
-    it('should keep the newer scene deployed and not install the older one', async () => {
-      const deployed = await deployedEntityIds()
-      expect(deployed).toEqual([newer.entityId])
+        beforeEach(async () => {
+          completeResponse = await post(makeForm(older.entityId, older.files, older.contentHashes, olderAuth))
+        })
+
+        it('should reject the stale finalize', () => {
+          expect(completeResponse.status).toBe(400)
+        })
+
+        it('should keep the newer scene deployed and not install the older one', async () => {
+          expect(await deployedEntityIds()).toEqual([newer.entityId])
+        })
+      })
     })
   })
 
   describe('when an over-budget partial request targets parcels held by another pending upload', () => {
-    let overBudgetResponse: Response
+    let stagingResponse: Awaited<ReturnType<typeof post>>
 
     beforeEach(async () => {
       // Shrink the world budget so any real content exceeds it.
@@ -352,23 +543,31 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
 
       // Stage upload A (entity only, zero content bytes so far) — passes the 1-byte budget.
       const aAuth = Authenticator.signPayload(identity.authChain, entityId)
-      expect((await post(buildForm([entityId], aAuth))).status).toBe(202)
-
-      // Upload B (a different entity on the same parcels) sends real content in one request; it is over
-      // budget and must be rejected WITHOUT destroying A's pending row.
-      const b = await buildScene(['20,24'], Date.now() + 1000)
-      const bAuth = Authenticator.signPayload(identity.authChain, b.entityId)
-      overBudgetResponse = (await post(
-        makeForm(b.entityId, b.files, [b.entityId, ...b.contentHashes], bAuth)
-      )) as unknown as Response
+      stagingResponse = await post(buildForm([entityId], aAuth))
     })
 
-    it('should reject the over-budget request', () => {
-      expect(overBudgetResponse.status).toBe(400)
+    it('should accept the zero-content staging request with 202', () => {
+      expect(stagingResponse.status).toBe(202)
     })
 
-    it("should preserve the other deployer's in-flight pending upload", async () => {
-      expect(await countPending()).toBe(1)
+    describe('and a different entity on the same parcels sends over-budget content in one request', () => {
+      let overBudgetResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        // Upload B (a different entity on the same parcels) sends real content in one request; it is over
+        // budget and must be rejected WITHOUT destroying A's pending row.
+        const b = await buildScene(['20,24'], Date.now() + 1000)
+        const bAuth = Authenticator.signPayload(identity.authChain, b.entityId)
+        overBudgetResponse = await post(makeForm(b.entityId, b.files, [b.entityId, ...b.contentHashes], bAuth))
+      })
+
+      it('should reject the over-budget request', () => {
+        expect(overBudgetResponse.status).toBe(400)
+      })
+
+      it("should preserve the other deployer's in-flight pending upload", async () => {
+        expect(await countPending()).toBe(1)
+      })
     })
   })
 })

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -1,0 +1,166 @@
+import { test } from '../components'
+import { DeploymentBuilder } from 'dcl-catalyst-client'
+import { AuthChain, EntityType } from '@dcl/schemas'
+import { Authenticator } from '@dcl/crypto'
+import { stringToUtf8Bytes } from 'eth-connect'
+import { getIdentity, Identity, makeid, cleanup } from '../utils'
+import FormData from 'form-data'
+
+test('Partial deployments POST /entities (partial=true)', function ({ components, stubComponents }) {
+  let identity: Identity
+  let worldName: string
+  let entityId: string
+  let files: Map<string, Uint8Array>
+  let contentHashes: string[]
+
+  afterEach(async () => {
+    jest.resetAllMocks()
+    const { storage, database } = components
+    await cleanup(storage, database)
+  })
+
+  function buildForm(keysToInclude: string[], authChain: AuthChain, partial = true): FormData {
+    const form = new FormData()
+    form.append('entityId', entityId)
+    if (partial) {
+      form.append('partial', 'true')
+    }
+    authChain.forEach((link, i) => {
+      form.append(`authChain[${i}][type]`, link.type)
+      form.append(`authChain[${i}][payload]`, link.payload)
+      form.append(`authChain[${i}][signature]`, link.signature ?? '')
+    })
+    for (const key of keysToInclude) {
+      form.append(key, Buffer.from(files.get(key)!), { filename: key })
+    }
+    return form
+  }
+
+  async function post(form: FormData) {
+    const { localFetch } = components
+    return localFetch.fetch('/entities', {
+      method: 'POST',
+      headers: form.getHeaders(),
+      body: form.getBuffer()
+    })
+  }
+
+  async function countPending(): Promise<number> {
+    const { database } = components
+    const result = await database.query<{ count: string }>('SELECT COUNT(*) as count FROM pending_scenes')
+    return parseInt(result.rows[0].count)
+  }
+
+  beforeEach(async () => {
+    const { worldCreator } = components
+    const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
+
+    identity = await getIdentity()
+    worldName = worldCreator.randomWorldName()
+
+    const entityFiles = new Map<string, Uint8Array>()
+    entityFiles.set('file1.txt', stringToUtf8Bytes(makeid(100)))
+    entityFiles.set('file2.txt', stringToUtf8Bytes(makeid(120)))
+
+    const result = await DeploymentBuilder.buildEntity({
+      type: EntityType.SCENE as any,
+      pointers: ['20,24'],
+      files: entityFiles,
+      metadata: {
+        main: 'file1.txt',
+        scene: { base: '20,24', parcels: ['20,24'] },
+        worldConfiguration: { name: worldName }
+      }
+    })
+    entityId = result.entityId
+    files = result.files
+    contentHashes = Array.from(files.keys()).filter((k) => k !== entityId)
+
+    namePermissionChecker.checkPermission.mockImplementation(
+      async (ethAddress, name) => ethAddress === identity.authChain.authChain[0].payload && name === worldName
+    )
+    nameOwnership.findOwners.mockImplementation(async (worldNames) =>
+      worldNames.length === 1 && worldNames[0] === worldName
+        ? new Map([[worldName, identity.authChain.authChain[0].payload]])
+        : new Map()
+    )
+    snsClient.publishMessage.mockResolvedValue({
+      MessageId: 'mocked-message-id',
+      SequenceNumber: 'mocked-sequence-number',
+      $metadata: {}
+    })
+  })
+
+  describe('when uploading a scene across multiple partial requests', () => {
+    it('should return 202 until the last request finalizes with 200 and makes the world live', async () => {
+      const { worldsManager } = components
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hash1, hash2] = contentHashes
+
+      const res1 = await post(buildForm([entityId], authChain))
+      expect(res1.status).toBe(202)
+      expect(new Set((await res1.json()).missing)).toEqual(new Set([hash1, hash2]))
+      expect(await countPending()).toBe(1)
+      // The world is not live yet.
+      expect(await worldsManager.getMetadataForWorld(worldName)).toBeUndefined()
+
+      const res2 = await post(buildForm([hash1], authChain))
+      expect(res2.status).toBe(202)
+      expect((await res2.json()).missing).toEqual([hash2])
+
+      const res3 = await post(buildForm([hash2], authChain))
+      expect(res3.status).toBe(200)
+      expect((await res3.json()).message).toContain(`Your scene was deployed to World "${worldName}"`)
+
+      expect(await countPending()).toBe(0)
+      expect(await worldsManager.getMetadataForWorld(worldName)).toBeDefined()
+    })
+
+    it('should not require the entity file on requests after the first', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+
+      const res1 = await post(buildForm([entityId, contentHashes[0]], authChain))
+      expect(res1.status).toBe(202)
+
+      // Second request omits the entity file; the server reads it back from storage.
+      const res2 = await post(buildForm([contentHashes[1]], authChain))
+      expect(res2.status).toBe(200)
+      expect(await countPending()).toBe(0)
+    })
+  })
+
+  describe('when a single partial request contains all content', () => {
+    it('should finalize immediately and return 200', async () => {
+      const { worldsManager } = components
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+
+      const res = await post(buildForm([entityId, ...contentHashes], authChain))
+      expect(res.status).toBe(200)
+      expect(await countPending()).toBe(0)
+      expect(await worldsManager.getMetadataForWorld(worldName)).toBeDefined()
+    })
+  })
+
+  describe('when the same partial request is replayed', () => {
+    it('should respond idempotently and keep a single pending row', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+
+      const res1 = await post(buildForm([entityId], authChain))
+      const res2 = await post(buildForm([entityId], authChain))
+
+      expect(res1.status).toBe(202)
+      expect(res2.status).toBe(202)
+      expect(new Set((await res2.json()).missing)).toEqual(new Set(contentHashes))
+      expect(await countPending()).toBe(1)
+    })
+  })
+
+  describe('when the first partial request omits the entity file', () => {
+    it('should return 400', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const res = await post(buildForm([contentHashes[0]], authChain))
+      expect(res.status).toBe(400)
+      expect(await countPending()).toBe(0)
+    })
+  })
+})

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -666,6 +666,40 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
     it('should keep the newer scene deployed', async () => {
       expect(await deployedEntityIds()).toEqual([newer.entityId])
     })
+
+    it('should not leave the rejected scene content in storage (rejected before storing)', async () => {
+      const stored = await components.storage.existMultiple(older.contentHashes)
+      expect([...stored.values()].some((present) => present)).toBe(false)
+    })
+  })
+
+  describe('when a deployer at the cap replaces one of their own pending uploads with a newer one', () => {
+    // Test config sets MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER=3.
+    let replaceResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
+      const now = Date.now()
+      // Fill the cap: three distinct uploads on disjoint parcels.
+      const parcels = [['20,24'], ['20,25'], ['20,26']]
+      const scenes = await Promise.all(parcels.map((p) => buildScene(p, now)))
+      for (const scene of scenes) {
+        const auth = Authenticator.signPayload(identity.authChain, scene.entityId)
+        await post(makeForm(scene.entityId, scene.files, [scene.entityId], auth))
+      }
+      // A newer upload overlapping the first one replaces it — the deployer's row count stays at 3, so
+      // the cap must NOT reject it (the decision is the net change, not a stale "is this new?" flag).
+      const replacement = await buildScene(['20,24'], now + 1000)
+      const replAuth = Authenticator.signPayload(identity.authChain, replacement.entityId)
+      replaceResponse = await post(makeForm(replacement.entityId, replacement.files, [replacement.entityId], replAuth))
+    })
+
+    it('should accept the replacement with 202 rather than rejecting it as over-cap', () => {
+      expect(replaceResponse.status).toBe(202)
+    })
+
+    it('should keep the deployer at the cap (net count unchanged)', async () => {
+      expect(await countPending()).toBe(3)
+    })
   })
 
   describe('when a deployer exceeds the concurrent-pending upload cap', () => {

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -149,6 +149,35 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
     })
   })
 
+  describe('when uploading across multiple requests (resume fast-path)', () => {
+    it('should run the deployment-permission check only on the first request and at finalize, not per batch', async () => {
+      const { namePermissionChecker } = stubComponents
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hashA, hashB] = contentHashes
+
+      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
+      expect((await post(buildForm([hashA], authChain))).status).toBe(202)
+      expect((await post(buildForm([hashB], authChain))).status).toBe(200)
+
+      // Request 1 (creates the pending record) runs the permission check; requests 2 and 3 are resume
+      // batches by the same deployer that skip it; finalize (inside request 3) re-runs it.
+      expect(namePermissionChecker.checkPermission).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not grant the fast path to a different signer resuming the same entity', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
+
+      // Another wallet (no deployment permission for this world) signs the same entity id and tries to
+      // continue the upload: it must go through the full staging validation and be rejected.
+      const otherIdentity = await getIdentity()
+      const otherAuthChain = Authenticator.signPayload(otherIdentity.authChain, entityId)
+      const res = await post(buildForm([contentHashes[0]], otherAuthChain))
+
+      expect(res.status).toBe(400)
+    })
+  })
+
   describe('when the same partial request is replayed', () => {
     it('should respond idempotently and keep a single pending row', async () => {
       const authChain = Authenticator.signPayload(identity.authChain, entityId)

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -51,6 +51,14 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
     return parseInt(result.rows[0].count)
   }
 
+  async function countDeployedScenes(): Promise<number> {
+    const { database } = components
+    const result = await database.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM world_scenes WHERE entity_id = '${entityId}' AND status = 'DEPLOYED'`
+    )
+    return parseInt(result.rows[0].count)
+  }
+
   beforeEach(async () => {
     const { worldCreator } = components
     const { namePermissionChecker, nameOwnership, snsClient } = stubComponents
@@ -160,6 +168,38 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       const authChain = Authenticator.signPayload(identity.authChain, entityId)
       const res = await post(buildForm([contentHashes[0]], authChain))
       expect(res.status).toBe(400)
+      expect(await countPending()).toBe(0)
+    })
+  })
+
+  describe('when staging requests for the same entity run in parallel', () => {
+    it('should accept two distinct content batches uploaded concurrently and deploy the world once', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hashA, hashB] = contentHashes
+
+      expect((await post(buildForm([entityId], authChain))).status).toBe(202)
+
+      const [resA, resB] = await Promise.all([post(buildForm([hashA], authChain)), post(buildForm([hashB], authChain))])
+
+      const statuses = [resA.status, resB.status].sort()
+      expect(statuses.every((status) => status === 200 || status === 202)).toBe(true)
+      expect(statuses).toContain(200)
+      expect(await countDeployedScenes()).toBe(1)
+      expect(await countPending()).toBe(0)
+    })
+
+    it('should deploy once when two requests complete the content set at the same time', async () => {
+      const authChain = Authenticator.signPayload(identity.authChain, entityId)
+      const [hashA, hashB] = contentHashes
+
+      // Stage entity + A, leaving only B missing.
+      expect((await post(buildForm([entityId, hashA], authChain))).status).toBe(202)
+
+      // Two identical completing requests (both upload B) race to finalize.
+      const [res1, res2] = await Promise.all([post(buildForm([hashB], authChain)), post(buildForm([hashB], authChain))])
+
+      expect([res1.status, res2.status].sort()).toEqual([200, 200])
+      expect(await countDeployedScenes()).toBe(1)
       expect(await countPending()).toBe(0)
     })
   })

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -6,6 +6,11 @@ import { stringToUtf8Bytes } from 'eth-connect'
 import { getIdentity, Identity, makeid, cleanup } from '../utils'
 import FormData from 'form-data'
 
+// Lower the per-deployer concurrent-pending cap so it's exercisable without staging 10+ uploads.
+// Runs at module evaluation, before the test harness initializes components in beforeAll, and
+// process.env wins over .env.default in env-config-provider.
+process.env.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER = '3'
+
 test('Partial deployments POST /entities (partial=true)', function ({ components, stubComponents }) {
   let identity: Identity
   let worldName: string
@@ -568,6 +573,86 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       it("should preserve the other deployer's in-flight pending upload", async () => {
         expect(await countPending()).toBe(1)
       })
+    })
+  })
+
+  describe('when a second partial upload targets parcels held by a pending upload', () => {
+    let older: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let newer: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let olderAuth: AuthChain
+    let newerAuth: AuthChain
+
+    beforeEach(async () => {
+      const now = Date.now()
+      older = await buildScene(['20,24'], now - 60_000)
+      newer = await buildScene(['20,24'], now)
+      olderAuth = Authenticator.signPayload(identity.authChain, older.entityId)
+      newerAuth = Authenticator.signPayload(identity.authChain, newer.entityId)
+    })
+
+    describe('and the incoming upload is newer than the pending one', () => {
+      let replaceResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        await post(makeForm(older.entityId, older.files, [older.entityId], olderAuth))
+        replaceResponse = await post(makeForm(newer.entityId, newer.files, [newer.entityId], newerAuth))
+      })
+
+      it('should accept it and replace the older pending upload', async () => {
+        expect(replaceResponse.status).toBe(202)
+        expect(await countPending()).toBe(1)
+      })
+
+      it('should leave the newer upload as the pending one', async () => {
+        const { database } = components
+        const result = await database.query<{ entity_id: string }>('SELECT entity_id FROM pending_scenes')
+        expect(result.rows.map((r) => r.entity_id)).toEqual([newer.entityId])
+      })
+    })
+
+    describe('and the incoming upload is older than the pending one', () => {
+      let rejectResponse: Awaited<ReturnType<typeof post>>
+
+      beforeEach(async () => {
+        await post(makeForm(newer.entityId, newer.files, [newer.entityId], newerAuth))
+        rejectResponse = await post(makeForm(older.entityId, older.files, [older.entityId], olderAuth))
+      })
+
+      it('should reject the older upload with 400', () => {
+        expect(rejectResponse.status).toBe(400)
+      })
+
+      it('should keep the newer upload as the sole pending one', async () => {
+        const { database } = components
+        const result = await database.query<{ entity_id: string }>('SELECT entity_id FROM pending_scenes')
+        expect(result.rows.map((r) => r.entity_id)).toEqual([newer.entityId])
+      })
+    })
+  })
+
+  describe('when a deployer exceeds the concurrent-pending upload cap', () => {
+    // Test config sets MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER=3.
+    let overCapResponse: Awaited<ReturnType<typeof post>>
+
+    beforeEach(async () => {
+      // Stage three distinct uploads (same deployer + world, disjoint parcels so none replace another).
+      const parcels = [['20,24'], ['20,25'], ['20,26'], ['20,27']]
+      const scenes = await Promise.all(parcels.map((p, i) => buildScene(p, Date.now() + i)))
+      for (let i = 0; i < 3; i++) {
+        const auth = Authenticator.signPayload(identity.authChain, scenes[i].entityId)
+        await post(makeForm(scenes[i].entityId, scenes[i].files, [scenes[i].entityId], auth))
+      }
+      // The fourth new upload exceeds the cap.
+      const fourthAuth = Authenticator.signPayload(identity.authChain, scenes[3].entityId)
+      overCapResponse = await post(makeForm(scenes[3].entityId, scenes[3].files, [scenes[3].entityId], fourthAuth))
+    })
+
+    it('should reject the upload beyond the cap with 400', () => {
+      expect(overCapResponse.status).toBe(400)
+    })
+
+    it('should not create a pending row for the rejected upload', async () => {
+      expect(await countPending()).toBe(3)
     })
   })
 })

--- a/test/integration/partial-deploy.spec.ts
+++ b/test/integration/partial-deploy.spec.ts
@@ -203,4 +203,125 @@ test('Partial deployments POST /entities (partial=true)', function ({ components
       expect(await countPending()).toBe(0)
     })
   })
+
+  // Generic form builder for a second entity (the module-level buildForm is bound to the beforeEach one).
+  function makeForm(id: string, fileMap: Map<string, Uint8Array>, keys: string[], authChain: AuthChain): FormData {
+    const form = new FormData()
+    form.append('entityId', id)
+    form.append('partial', 'true')
+    authChain.forEach((link, i) => {
+      form.append(`authChain[${i}][type]`, link.type)
+      form.append(`authChain[${i}][payload]`, link.payload)
+      form.append(`authChain[${i}][signature]`, link.signature ?? '')
+    })
+    for (const key of keys) {
+      form.append(key, Buffer.from(fileMap.get(key)!), { filename: key })
+    }
+    return form
+  }
+
+  // Builds a scene for the current world on the given parcels at an explicit timestamp (so two scenes
+  // can differ only by timestamp, producing distinct entity ids that order deterministically).
+  async function buildScene(pointers: string[], timestamp: number) {
+    const sceneFiles = new Map<string, Uint8Array>()
+    sceneFiles.set('file1.txt', stringToUtf8Bytes(makeid(100)))
+    const built = await DeploymentBuilder.buildEntity({
+      type: EntityType.SCENE as any,
+      pointers,
+      files: sceneFiles,
+      timestamp,
+      metadata: {
+        main: 'file1.txt',
+        scene: { base: pointers[0], parcels: pointers },
+        worldConfiguration: { name: worldName }
+      }
+    })
+    return {
+      entityId: built.entityId,
+      files: built.files,
+      contentHashes: Array.from(built.files.keys()).filter((k) => k !== built.entityId)
+    }
+  }
+
+  async function deployedEntityIds(): Promise<string[]> {
+    const { database } = components
+    const result = await database.query<{ entity_id: string }>(
+      `SELECT entity_id FROM world_scenes WHERE world_name = '${worldName.toLowerCase()}' AND status = 'DEPLOYED'`
+    )
+    return result.rows.map((r) => r.entity_id)
+  }
+
+  describe('when a stale pending upload would finalize over a newer deployment', () => {
+    let older: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let newer: { entityId: string; files: Map<string, Uint8Array>; contentHashes: string[] }
+    let completeResponse: Response
+
+    beforeEach(async () => {
+      const now = Date.now()
+      older = await buildScene(['20,24'], now - 60_000)
+      newer = await buildScene(['20,24'], now)
+
+      // Stage the older scene partially (entity only) — no newer scene exists yet, so this is accepted.
+      const olderAuth = Authenticator.signPayload(identity.authChain, older.entityId)
+      const stageOlder = await post(makeForm(older.entityId, older.files, [older.entityId], olderAuth))
+      expect(stageOlder.status).toBe(202)
+
+      // A newer scene is then deployed on the same parcels via a normal single-request deploy.
+      const newerAuth = Authenticator.signPayload(identity.authChain, newer.entityId)
+      const newerForm = new FormData()
+      newerForm.append('entityId', newer.entityId)
+      newerAuth.forEach((link, i) => {
+        newerForm.append(`authChain[${i}][type]`, link.type)
+        newerForm.append(`authChain[${i}][payload]`, link.payload)
+        newerForm.append(`authChain[${i}][signature]`, link.signature ?? '')
+      })
+      for (const key of [newer.entityId, ...newer.contentHashes]) {
+        newerForm.append(key, Buffer.from(newer.files.get(key)!), { filename: key })
+      }
+      expect((await post(newerForm)).status).toBe(200)
+
+      // Now the stalled client completes the older upload.
+      completeResponse = (await post(
+        makeForm(older.entityId, older.files, older.contentHashes, olderAuth)
+      )) as unknown as Response
+    })
+
+    it('should reject the stale finalize', () => {
+      expect(completeResponse.status).toBe(400)
+    })
+
+    it('should keep the newer scene deployed and not install the older one', async () => {
+      const deployed = await deployedEntityIds()
+      expect(deployed).toEqual([newer.entityId])
+    })
+  })
+
+  describe('when an over-budget partial request targets parcels held by another pending upload', () => {
+    let overBudgetResponse: Response
+
+    beforeEach(async () => {
+      // Shrink the world budget so any real content exceeds it.
+      jest.spyOn(components.limitsManager, 'getMaxAllowedSizeInBytesFor').mockResolvedValue(1n)
+
+      // Stage upload A (entity only, zero content bytes so far) — passes the 1-byte budget.
+      const aAuth = Authenticator.signPayload(identity.authChain, entityId)
+      expect((await post(buildForm([entityId], aAuth))).status).toBe(202)
+
+      // Upload B (a different entity on the same parcels) sends real content in one request; it is over
+      // budget and must be rejected WITHOUT destroying A's pending row.
+      const b = await buildScene(['20,24'], Date.now() + 1000)
+      const bAuth = Authenticator.signPayload(identity.authChain, b.entityId)
+      overBudgetResponse = (await post(
+        makeForm(b.entityId, b.files, [b.entityId, ...b.contentHashes], bAuth)
+      )) as unknown as Response
+    })
+
+    it('should reject the over-budget request', () => {
+      expect(overBudgetResponse.status).toBe(400)
+    })
+
+    it("should preserve the other deployer's in-flight pending upload", async () => {
+      expect(await countPending()).toBe(1)
+    })
+  })
 })

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -2,6 +2,7 @@ import { createEvictionJob } from '../../src/adapters/eviction-job'
 import { createMockWorlds } from '../mocks/worlds-mock'
 import { createMockedConfig } from '../mocks/config-mock'
 import { IWorldsComponent } from '../../src/logic/worlds/types'
+import { IPendingScenesManager } from '../../src/types'
 import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { createJobComponent } from '@dcl/job-component'
 
@@ -17,10 +18,17 @@ const mockCreateJobComponent = createJobComponent as jest.Mock
 describe('EvictionJob', () => {
   let worlds: jest.Mocked<IWorldsComponent>
   let logs: ILoggerComponent
+  let pendingScenesManager: jest.Mocked<IPendingScenesManager>
 
   beforeEach(() => {
     worlds = createMockWorlds()
     worlds.evictUndeployedWorlds.mockResolvedValue(0)
+    pendingScenesManager = {
+      getByEntityId: jest.fn(),
+      upsert: jest.fn(),
+      deleteByEntityId: jest.fn(),
+      deleteExpired: jest.fn().mockResolvedValue(0)
+    }
     logs = {
       getLogger: () => ({
         log: jest.fn(),
@@ -43,7 +51,7 @@ describe('EvictionJob', () => {
 
     beforeEach(async () => {
       config = createMockedConfig({ getNumber: jest.fn().mockResolvedValue(3600000) })
-      await createEvictionJob({ config, logs, worlds })
+      await createEvictionJob({ config, logs, worlds, pendingScenesManager })
       jobCallback = mockCreateJobComponent.mock.calls[0][1]
     })
 
@@ -69,7 +77,7 @@ describe('EvictionJob', () => {
 
     beforeEach(async () => {
       config = createMockedConfig({ getNumber: jest.fn().mockResolvedValue(undefined) })
-      await createEvictionJob({ config, logs, worlds })
+      await createEvictionJob({ config, logs, worlds, pendingScenesManager })
       jobCallback = mockCreateJobComponent.mock.calls[0][1]
     })
 

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -28,8 +28,7 @@ describe('EvictionJob', () => {
       upsert: jest.fn(),
       deleteByEntityId: jest.fn(),
       deleteExpired: jest.fn().mockResolvedValue(0),
-      getActivePendingKeys: jest.fn().mockResolvedValue(new Set()),
-      countActiveByDeployer: jest.fn().mockResolvedValue(0)
+      getActivePendingKeys: jest.fn().mockResolvedValue(new Set())
     }
     logs = {
       getLogger: () => ({

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -28,7 +28,8 @@ describe('EvictionJob', () => {
       upsert: jest.fn(),
       deleteByEntityId: jest.fn(),
       deleteExpired: jest.fn().mockResolvedValue(0),
-      getActivePendingKeys: jest.fn().mockResolvedValue(new Set())
+      getActivePendingKeys: jest.fn().mockResolvedValue(new Set()),
+      countActiveByDeployer: jest.fn().mockResolvedValue(0)
     }
     logs = {
       getLogger: () => ({

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -27,7 +27,8 @@ describe('EvictionJob', () => {
       getByEntityId: jest.fn(),
       upsert: jest.fn(),
       deleteByEntityId: jest.fn(),
-      deleteExpired: jest.fn().mockResolvedValue(0)
+      deleteExpired: jest.fn().mockResolvedValue(0),
+      getActivePendingKeys: jest.fn().mockResolvedValue(new Set())
     }
     logs = {
       getLogger: () => ({
@@ -67,6 +68,10 @@ describe('EvictionJob', () => {
 
       it('should call evictUndeployedWorlds with the configured TTL', () => {
         expect(worlds.evictUndeployedWorlds).toHaveBeenCalledWith(3600000)
+      })
+
+      it('should delete expired pending scenes', () => {
+        expect(pendingScenesManager.deleteExpired).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -2,7 +2,7 @@ import { createEvictionJob } from '../../src/adapters/eviction-job'
 import { createMockWorlds } from '../mocks/worlds-mock'
 import { createMockedConfig } from '../mocks/config-mock'
 import { IWorldsComponent } from '../../src/logic/worlds/types'
-import { IPendingScenesManager } from '../../src/types'
+import { IPendingScenesManager } from '../../src/adapters/pending-scenes-manager/types'
 import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { createJobComponent } from '@dcl/job-component'
 

--- a/test/unit/eviction-job.spec.ts
+++ b/test/unit/eviction-job.spec.ts
@@ -28,7 +28,9 @@ describe('EvictionJob', () => {
       upsert: jest.fn(),
       deleteByEntityId: jest.fn(),
       deleteExpired: jest.fn().mockResolvedValue(0),
-      getActivePendingKeys: jest.fn().mockResolvedValue(new Set())
+      getActivePendingKeys: jest.fn().mockResolvedValue(new Set()),
+      acquireFinalizationLease: jest.fn().mockResolvedValue(true),
+      releaseFinalizationLease: jest.fn().mockResolvedValue(undefined)
     }
     logs = {
       getLogger: () => ({

--- a/test/unit/validations/common.spec.ts
+++ b/test/unit/validations/common.spec.ts
@@ -11,7 +11,8 @@ import {
   validateAuthChain,
   validateBaseEntity,
   validateEntityId,
-  validateFiles,
+  validateUploadedFiles,
+  validateNoMissingFiles,
   validateSignature,
   validateSigner,
   validateSupportedEntityType
@@ -194,32 +195,22 @@ describe('common validations', function () {
     })
   })
 
-  describe('validateFiles', () => {
-    it('validateFiles OK', async () => {
-      const entityFiles = new Map<string, Uint8Array>()
-      entityFiles.set('abc.txt', Buffer.from(stringToUtf8Bytes('asd')))
-
+  describe('validateUploadedFiles', () => {
+    it('validateUploadedFiles OK', async () => {
       const deployment = await createSceneDeployment(identity.authChain)
 
-      const result = await validateFiles(deployment)
+      const result = await validateUploadedFiles(deployment)
       expect(result.ok()).toBeTruthy()
     })
 
-    it('validateFiles with errors', async () => {
-      const entityFiles = new Map<string, Uint8Array>()
-      entityFiles.set('abc.txt', Buffer.from(stringToUtf8Bytes('asd')))
-
+    it('validateUploadedFiles with errors', async () => {
       const deployment = await createSceneDeployment(identity.authChain)
 
-      // Alter the files to make it fail
+      // Alter the files to make it fail: an extra file not in the entity, and a non-CIDv1 hash.
       deployment.files.set(await hashV1(Buffer.from('efg')), bufferToDeploymentFile(Buffer.from('efg')))
       deployment.files.set(await hashV0(Buffer.from('igh')), bufferToDeploymentFile(Buffer.from('igh')))
-      deployment.entity.content.push({
-        file: 'def.txt',
-        hash: 'bafkreie3yaomoex7orli7fumfwgk5abgels5o5fiauxfijzlzoiymqppdi'
-      })
 
-      const result = await validateFiles(deployment)
+      const result = await validateUploadedFiles(deployment)
       expect(result.ok()).toBeFalsy()
       expect(result.errors).toContain('Extra file detected bafkreigu77uot3qljdv2oftqmer2ogd7glvohpolbz3whza6kmzgppmkkm')
       expect(result.errors).toContain(
@@ -228,6 +219,28 @@ describe('common validations', function () {
       expect(result.errors).toContain(
         "The hashed file doesn't match the provided content: QmPeE5zaej9HogrHRfS1NejWsTuh4qcFZCc4Q7LMnwdTMK"
       )
+    })
+  })
+
+  describe('validateNoMissingFiles', () => {
+    it('validateNoMissingFiles OK', async () => {
+      const deployment = await createSceneDeployment(identity.authChain)
+
+      const result = await validateNoMissingFiles(deployment)
+      expect(result.ok()).toBeTruthy()
+    })
+
+    it('validateNoMissingFiles with a referenced-but-absent file', async () => {
+      const deployment = await createSceneDeployment(identity.authChain)
+
+      // Reference a file that is neither uploaded nor stored.
+      deployment.entity.content.push({
+        file: 'def.txt',
+        hash: 'bafkreie3yaomoex7orli7fumfwgk5abgels5o5fiauxfijzlzoiymqppdi'
+      })
+
+      const result = await validateNoMissingFiles(deployment)
+      expect(result.ok()).toBeFalsy()
       expect(result.errors).toContain(
         'The file bafkreie3yaomoex7orli7fumfwgk5abgels5o5fiauxfijzlzoiymqppdi (def.txt) is neither present in the storage or in the provided entity'
       )

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -37,7 +37,8 @@ export async function cleanup(storage: IContentStorageComponent, db: IPgComponen
   }
   await storage.delete(files)
 
-  await db.query(`TRUNCATE worlds, world_scenes CASCADE`)
+  // `pending_scenes` has no FK to `worlds`, so the CASCADE above never reaches it — truncate explicitly.
+  await db.query(`TRUNCATE worlds, world_scenes, pending_scenes CASCADE`)
 }
 
 export async function getIdentity(ephemeralKeyTTLInMinutes = 10): Promise<Identity> {


### PR DESCRIPTION
## what

adds support for uploading a world scene's content across several `POST /entities` requests instead of a single one, so scenes too large for one request can be deployed. a world does not become live until all of its content is present. mirrors the partial-upload protocol added to the catalyst content server so the same endpoint and client work against both.

## how

- a new optional `partial=true` form field on `POST /entities` marks a staging request. requests without the flag behave exactly as today.
- per staging request the server authenticates, runs every validation that does not depend on the full content set (entity id/hash, signature, scene schema, coordinates/pointers/dimensions, banned names, deployment permission, "reject extras"), stores the uploaded files, and records/refreshes a pending scene.
- a cumulative size check enforces the world's size budget as content accumulates.
- when a request completes the content set the server runs the full validation + `entityDeployer.deployEntity` in that same request and returns `200` (today's body); otherwise it returns `202 { missing: [hashes] }`.
- at most one pending scene may exist per world + overlapping parcels: a newer partial deploy replaces it.
- the deployment-ttl check is anchored on when the upload started (the pending row's `created_at`) so an upload can span longer than the ttl.
- garbage collection keeps non-expired pending entity ids + content hashes; the eviction job removes pending rows older than `PENDING_DEPLOYMENT_TTL` (default 24h).

## key changes

- new standalone `pending_scenes` table (migration `0025`) + `src/adapters/pending-scenes-manager.ts`. no foreign key to `worlds` so a half-uploaded world never leaks into listings/validity checks before it is live.
- new `src/logic/partial-deployments/` orchestration component.
- `validateFiles` split into `validateUploadedFiles` (both phases) and `validateNoMissingFiles` (finalize only); new `validator.validateStaging`.
- `deploy-entity-handler` partial branch + entity-file-from-storage fallback + ttl anchoring + pending-row cleanup on vanilla deploy.
- gc handler and eviction job extended.

## testing

- new integration tests in `test/integration/partial-deploy.spec.ts` (multi-batch upload, resume/idempotency, single-request auto-finalize, missing entity file; world only live after finalize).
- unit tests updated for the validations split and the eviction-job change.
- existing deploy, parcel-permission, validations and garbage-collection suites pass unchanged.
- `yarn build` clean.

## follow-ups (out of scope)

- document the `partial` field and `202` response in `docs/openapi.yaml`.
- bump `dcl-catalyst-client` once its batched deploy method ships.
